### PR TITLE
Disable blacklist filtering when array not defined

### DIFF
--- a/Missionframework/scripts/client/misc/init_arsenal.sqf
+++ b/Missionframework/scripts/client/misc/init_arsenal.sqf
@@ -1,8 +1,15 @@
 if ( isNil "GRLIB_arsenal_weapons" ) then { GRLIB_arsenal_weapons = [] };
+// Use weapon blacklist when whitelist is empty
 if ( count GRLIB_arsenal_weapons == 0 ) then {
 	private _virtualStuffWeapons = [] call LARs_fnc_addWeapons;
 	private _virtualWeapons = [];
-	{ if ( !(_x in blacklisted_from_arsenal_weapons) ) then { _virtualWeapons pushback _x } } foreach (_virtualStuffWeapons);
+
+	// Don't try to filter weapons when blacklist is not defined
+	if ( isNil "blacklisted_from_arsenal_weapons" ) then {
+		_virtualWeapons = _virtualStuffWeapons;
+	} else {
+		{ if ( !(_x in blacklisted_from_arsenal_weapons) ) then { _virtualWeapons pushback _x } } foreach (_virtualStuffWeapons);
+	};
 	
 	[ missionNamespace, _virtualWeapons ] call BIS_fnc_addVirtualWeaponCargo;
 } else {
@@ -10,10 +17,17 @@ if ( count GRLIB_arsenal_weapons == 0 ) then {
 };
 
 if ( isNil "GRLIB_arsenal_magazines" ) then { GRLIB_arsenal_magazines = [] };
+// Use magazine blacklist when whitelist is empty
 if ( count GRLIB_arsenal_magazines == 0 ) then {
 	private _virtualStuffMagazines = [] call LARs_fnc_addMagazines;
 	private _virtualMagazines = [];
-	{ if ( !(_x in blacklisted_from_arsenal_magazines) ) then { _virtualMagazines pushback _x } } foreach (_virtualStuffMagazines);
+	
+	// Don't try to filter magazines when blacklist is not defined
+	if (isNil "blacklisted_from_arsenal_magazines") then {
+		_virtualMagazines = _virtualStuffMagazines;
+	} else {
+		{ if ( !(_x in blacklisted_from_arsenal_magazines) ) then { _virtualMagazines pushback _x } } foreach (_virtualStuffMagazines);
+	};
 	
 	[ missionNamespace, _virtualMagazines ] call BIS_fnc_addVirtualMagazineCargo;
 } else {
@@ -21,10 +35,17 @@ if ( count GRLIB_arsenal_magazines == 0 ) then {
 };
 
 if ( isNil "GRLIB_arsenal_items" ) then { GRLIB_arsenal_items = [] };
+// Use item blacklist when whitelist is empty
 if ( count GRLIB_arsenal_items == 0 ) then {
 	private _virtualStuffItems = [] call LARs_fnc_addItems;
 	private _virtualItems = [];
-	{ if ( !(_x in blacklisted_from_arsenal_items) ) then { _virtualItems pushback _x } } foreach (_virtualStuffItems);
+	
+	// Don't try to filter items when blacklist is not defined
+	if (isNil "blacklisted_from_arsenal_items") then {
+		_virtualItems = _virtualStuffItems;
+	} else {
+		{ if ( !(_x in blacklisted_from_arsenal_items) ) then { _virtualItems pushback _x } } foreach (_virtualStuffItems);
+	};
 	
 	[ missionNamespace, _virtualItems ] call BIS_fnc_addVirtualItemCargo;
 } else {
@@ -32,10 +53,17 @@ if ( count GRLIB_arsenal_items == 0 ) then {
 };
 
 if ( isNil "GRLIB_arsenal_backpacks" ) then { GRLIB_arsenal_backpacks = [] };
+// Use backpack blacklist when whitelist is empty
 if ( count GRLIB_arsenal_backpacks == 0 ) then {
 	private _virtualStuffBackpacks = [] call LARs_fnc_addBackpacks;
 	private _virtualBackpacks = [];
-	{ if ( !(_x in GRLIB_blacklisted_from_arsenal) ) then { _virtualBackpacks pushback _x } } foreach (_virtualStuffBackpacks);
+	
+	// Don't try to filter backpacks when blacklist is not defined
+	if (isNil "GRLIB_blacklisted_from_arsenal") then {
+		_virtualBackpacks = _virtualStuffBackpacks;
+	} else {
+		{ if ( !(_x in GRLIB_blacklisted_from_arsenal) ) then { _virtualBackpacks pushback _x } } foreach (_virtualStuffBackpacks);
+	};
 
 	[ missionNamespace, _virtualBackpacks ] call BIS_fnc_addVirtualBackpackCargo;
 } else {


### PR DESCRIPTION
This commit disables weapon blacklist filtering when blacklist array is not defined. 

I have noticed that when blacklist arrays are empty in preset then there are some errors in RPT. This fixes these errors.