### PR TITLE
Check is player commander via unit name instead of classname

### DIFF
--- a/Missionframework/presets/apex_tanoa.sqf
+++ b/Missionframework/presets/apex_tanoa.sqf
@@ -16,7 +16,6 @@ huron_typename = "B_Heli_Transport_03_unarmed_F";					// Default "B_Heli_Transpo
 ammobox_b_typename = "Box_NATO_AmmoVeh_F";				// Default "Box_NATO_AmmoVeh_F";
 ammobox_o_typename = "Box_East_AmmoVeh_F";				// Default "Box_East_AmmoVeh_F";
 opfor_ammobox_transport = "O_T_Truck_03_transport_ghex_F";			// Default "O_Truck_03_transport_F";    // Make sure this thing can transport ammo boxes (see box_transport_config down below) otherwise things will break
-commander_classname = "B_officer_F";				// Default "B_officer_F"
 crewman_classname = "B_crew_F";				// Default "B_crew_F";
 pilot_classname = "B_Helipilot_F";					// Default "B_Helipilot_F";
 KP_liberation_little_bird_classname = "B_Heli_Light_01_F"; // Default "B_Heli_Light_01_F" // classname of little birds that spawn on the lhd or chimera base

--- a/Missionframework/presets/custom.sqf
+++ b/Missionframework/presets/custom.sqf
@@ -16,7 +16,6 @@ huron_typename = "B_Heli_Transport_03_unarmed_F";					// Default "B_Heli_Transpo
 ammobox_b_typename = "Box_NATO_AmmoVeh_F";				// Default "Box_NATO_AmmoVeh_F";
 ammobox_o_typename = "Box_East_AmmoVeh_F";				// Default "Box_East_AmmoVeh_F";
 opfor_ammobox_transport = "O_Truck_03_transport_F";			// Default "O_Truck_03_transport_F";    // Make sure this thing can transport ammo boxes (see box_transport_config down below) otherwise things will break
-commander_classname = "B_officer_F";				// Default "B_officer_F"
 crewman_classname = "B_crew_F";				// Default "B_crew_F";
 pilot_classname = "B_Helipilot_F";					// Default "B_Helipilot_F";
 KP_liberation_little_bird_classname = "B_Heli_Light_01_F"; // Default "B_Heli_Light_01_F" // classname of little birds that spawn on the lhd or chimera base

--- a/Missionframework/presets/rhs.sqf
+++ b/Missionframework/presets/rhs.sqf
@@ -20,7 +20,6 @@ huron_typename = "RHS_CH_47F";					// Default "B_Heli_Transport_03_unarmed_F";
 ammobox_b_typename = "Box_NATO_AmmoVeh_F";				// Default "Box_NATO_AmmoVeh_F";
 ammobox_o_typename = "Box_East_AmmoVeh_F";				// Default "Box_East_AmmoVeh_F";
 opfor_ammobox_transport = "O_Truck_03_transport_F";			// Default "O_Truck_03_transport_F";    // Make sure this thing can transport ammo boxes (see box_transport_config down below) otherwise things will break
-commander_classname = "B_officer_F";				// Default "B_officer_F"
 crewman_classname = "B_crew_F";				// Default "B_crew_F";
 pilot_classname = "B_Helipilot_F";					// Default "B_Helipilot_F";
 KP_liberation_little_bird_classname = "RHS_MELB_MH6M"; // Default "B_Heli_Light_01_F" // classname of little birds that spawn on the lhd or chimera base

--- a/Missionframework/presets/rhs_bw.sqf
+++ b/Missionframework/presets/rhs_bw.sqf
@@ -21,7 +21,6 @@ huron_typename = "RHS_CH_47F";					// Default "B_Heli_Transport_03_unarmed_F";
 ammobox_b_typename = "Box_NATO_AmmoVeh_F";				// Default "Box_NATO_AmmoVeh_F";
 ammobox_o_typename = "Box_East_AmmoVeh_F";				// Default "Box_East_AmmoVeh_F";
 opfor_ammobox_transport = "O_Truck_03_transport_F";			// Default "O_Truck_03_transport_F";    // Make sure this thing can transport ammo boxes (see box_transport_config down below) otherwise things will break
-commander_classname = "B_officer_F";				// Default "B_officer_F"
 crewman_classname = "B_crew_F";				// Default "B_crew_F";
 pilot_classname = "B_Helipilot_F";					// Default "B_Helipilot_F";
 KP_liberation_little_bird_classname = "RHS_MELB_MH6M"; // Default "B_Heli_Light_01_F" // classname of little birds that spawn on the lhd or chimera base

--- a/Missionframework/presets/rhs_takistan.sqf
+++ b/Missionframework/presets/rhs_takistan.sqf
@@ -21,7 +21,6 @@ huron_typename = "RHS_CH_47F_10";					// Default "B_Heli_Transport_03_unarmed_F"
 ammobox_b_typename = "Box_NATO_AmmoVeh_F";				// Default "Box_NATO_AmmoVeh_F";
 ammobox_o_typename = "Box_East_AmmoVeh_F";				// Default "Box_East_AmmoVeh_F";
 opfor_ammobox_transport = "O_Truck_03_transport_F";			// Default "O_Truck_03_transport_F";    // Make sure this thing can transport ammo boxes (see box_transport_config down below) otherwise things will break
-commander_classname = "B_officer_F";				// Default "B_officer_F"
 crewman_classname = "B_crew_F";				// Default "B_crew_F";
 pilot_classname = "B_Helipilot_F";					// Default "B_Helipilot_F";
 KP_liberation_little_bird_classname = "RHS_MELB_MH6M"; // Default "B_Heli_Light_01_F" // classname of little birds that spawn on the lhd or chimera base

--- a/Missionframework/presets/vanilla.sqf
+++ b/Missionframework/presets/vanilla.sqf
@@ -16,7 +16,6 @@ huron_typename = nil;						// Default "B_Heli_Transport_03_unarmed_F";
 ammobox_b_typename = nil;					// Default "Box_NATO_AmmoVeh_F";
 ammobox_o_typename = nil;					// Default "Box_East_AmmoVeh_F";
 opfor_ammobox_transport = nil;				// Default "O_Truck_03_transport_F";    // Make sure this thing can transport ammo boxes (see box_transport_config down below) otherwise things will break
-commander_classname = nil;					// Default "B_officer_F"
 crewman_classname = nil;					// Default "B_crew_F";
 pilot_classname = nil;						// Default "B_Helipilot_F";
 KP_liberation_little_bird_classname = nil;	// Default "B_Heli_Light_01_F" // classname of little birds that spawn on the lhd or chimera base

--- a/Missionframework/scripts/shared/classnames.sqf
+++ b/Missionframework/scripts/shared/classnames.sqf
@@ -15,7 +15,6 @@ if ( isNil "huron_typename" ) then { huron_typename = "B_Heli_Transport_03_unarm
 if ( isNil "ammobox_b_typename" ) then { ammobox_b_typename = "Box_NATO_AmmoVeh_F"; };
 if ( isNil "ammobox_o_typename" ) then { ammobox_o_typename = "Box_East_AmmoVeh_F"; };
 if ( isNil "opfor_ammobox_transport" ) then { opfor_ammobox_transport = "O_Truck_03_transport_F"; };
-if ( isNil "commander_classname" ) then { commander_classname = "B_officer_F"; };
 if ( isNil "crewman_classname" ) then { crewman_classname = "B_crew_F" };
 if ( isNil "pilot_classname" ) then { pilot_classname = "B_Helipilot_F" };
 if ( isNil "KP_liberation_little_bird_classname" ) then { KP_liberation_little_bird_classname = "B_Heli_Light_01_F" };

--- a/Missionframework/scripts/shared/functions/F_getCommander.sqf
+++ b/Missionframework/scripts/shared/functions/F_getCommander.sqf
@@ -2,6 +2,6 @@ private [ "_commanderobj" ];
 
 _commanderobj = objNull;
 
-{ if ( typeOf _x == commander_classname ) exitWith { _commanderobj = _x }; } foreach allPlayers;
+{ if ( _x == commandant ) exitWith { _commanderobj = _x }; } foreach allPlayers;
 
 _commanderobj


### PR DESCRIPTION
Remove _commander_classname_ from presets and update _F_getCommander_ function to check is player a commander depending on unit name which is already used to give zeus ownership.

There is no point to have this classname in presets when commander slot is defined in mission (unit with name _commandant_)