### PR TITLE
set_skill.sqf bugfix

### DIFF
--- a/Missionframework/scripts/shared/set_skill.sqf
+++ b/Missionframework/scripts/shared/set_skill.sqf
@@ -34,8 +34,9 @@ if ( _wounded ) then {
 		if ( _inVehicle ) then {
 			_unit setSkill ["aimingaccuracy", [ 0.65 * _skillmodifier ] call F_limitSkill];
 		} else {
-			_unit setSkill ["aimingshake", [ 0.35 * _skillmodifier ] call F_limitSkill];
+			_unit setSkill ["aimingaccuracy", [ 0.35 * _skillmodifier ] call F_limitSkill];
 		};
+		_unit setSkill ["aimingshake", [ 0.35 * _skillmodifier ] call F_limitSkill];
 		_unit setSkill ["spottime", [ 0.5 * _skillmodifier ] call F_limitSkill];
 		_unit setSkill ["spotdistance", [ 0.5 * _skillmodifier ] call F_limitSkill];
 		_unit setSkill ["commanding", 0.5];


### PR DESCRIPTION
set_skill.sqf change to fix a bug that prevents aimingaccuracy variable from updating after a unit leaves a car or is healed.