### PR TITLE
Add param allowing to disable clearing of vehicles inventory/cargo

### DIFF
--- a/Missionframework/scripts/client/build/do_build.sqf
+++ b/Missionframework/scripts/client/build/do_build.sqf
@@ -293,7 +293,7 @@ while { true } do {
 					_vehicle setpos _truepos;
 				};
 				
-				if (!(_classname in KP_liberation_ace_crates)) then {
+				if (!(_classname in KP_liberation_ace_crates) && KP_liberation_clear_cargo) then {
 					clearWeaponCargoGlobal _vehicle;
 					clearMagazineCargoGlobal _vehicle;
 					clearItemCargoGlobal _vehicle;

--- a/Missionframework/scripts/server/base/huron_manager.sqf
+++ b/Missionframework/scripts/server/base/huron_manager.sqf
@@ -27,10 +27,12 @@ while { true } do {
 
 	huron AnimateDoor ["Door_rear_source", 1, true];
 	publicVariable "huron";
-	clearWeaponCargoGlobal huron;
-	clearMagazineCargoGlobal huron;
-	clearItemCargoGlobal huron;
-	clearBackpackCargoGlobal huron;
+	if(KP_liberation_clear_cargo) then {
+		clearWeaponCargoGlobal huron;
+		clearMagazineCargoGlobal huron;
+		clearItemCargoGlobal huron;
+		clearBackpackCargoGlobal huron;
+	};
 	huron setDamage 0;
 	sleep 0.5;
 	huron enableSimulationGlobal true;

--- a/Missionframework/scripts/server/base/startvehicle_spawn.sqf
+++ b/Missionframework/scripts/server/base/startvehicle_spawn.sqf
@@ -8,10 +8,12 @@ for [{_i=0}, {!isNil ("littlebird_" + str _i)}, {_i = _i + 1}] do {
 	_KP_liberation_little_bird allowdamage false;
 	_KP_liberation_little_bird setDir (getDir _KP_liberation_little_bird_pad);
 	_KP_liberation_little_bird setposATL [((getposATL _KP_liberation_little_bird_pad) select 0),((getposATL _KP_liberation_little_bird_pad) select 1),((getposATL _KP_liberation_little_bird_pad) select 2) + 0.1];
-	clearWeaponCargoGlobal _KP_liberation_little_bird;
-	clearMagazineCargoGlobal _KP_liberation_little_bird;
-	clearItemCargoGlobal _KP_liberation_little_bird;
-	clearBackpackCargoGlobal _KP_liberation_little_bird;
+	if(KP_liberation_clear_cargo) then {
+		clearWeaponCargoGlobal _KP_liberation_little_bird;
+		clearMagazineCargoGlobal _KP_liberation_little_bird;
+		clearItemCargoGlobal _KP_liberation_little_bird;
+		clearBackpackCargoGlobal _KP_liberation_little_bird;
+	};
 	sleep 0.5;
 	_KP_liberation_little_bird enableSimulationGlobal true;
 	_KP_liberation_little_bird setDamage 0;
@@ -26,10 +28,12 @@ for [{_i=0}, {!isNil ("boat_" + str _i)}, {_i = _i + 1}] do {
 	_KP_liberation_boat allowdamage false;
 	_KP_liberation_boat setDir (getDir _KP_liberation_boat_spawn);
 	_KP_liberation_boat setposATL (getposATL _KP_liberation_boat_spawn);
-	clearWeaponCargoGlobal _KP_liberation_boat;
-	clearMagazineCargoGlobal _KP_liberation_boat;
-	clearItemCargoGlobal _KP_liberation_boat;
-	clearBackpackCargoGlobal _KP_liberation_boat;
+	if(KP_liberation_clear_cargo) then {
+		clearWeaponCargoGlobal _KP_liberation_boat;
+		clearMagazineCargoGlobal _KP_liberation_boat;
+		clearItemCargoGlobal _KP_liberation_boat;
+		clearBackpackCargoGlobal _KP_liberation_boat;
+	};
 	sleep 0.5;
 	_KP_liberation_boat enableSimulationGlobal true;
 	_KP_liberation_boat setDamage 0;

--- a/Missionframework/scripts/shared/fetch_params.sqf
+++ b/Missionframework/scripts/shared/fetch_params.sqf
@@ -42,6 +42,7 @@ if ( isMultiplayer ) then {
 	KP_liberation_kill_debug = ["DebugKill",0] call bis_fnc_getParamValue;
 	KP_liberation_production_debug = ["DebugProduction",0] call bis_fnc_getParamValue;
 	KP_liberation_respawn_cooldown = ["RespawnCooldown",900] call bis_fnc_getParamValue;
+	KP_liberation_clear_cargo = ["ClearCargo",1] call bis_fnc_getParamValue;
 } else {
 	GRLIB_difficulty_modifier = 2;
 	GRLIB_time_factor = 12;
@@ -86,6 +87,7 @@ if ( isMultiplayer ) then {
 	KP_liberation_kill_debug = 0;
 	KP_liberation_production_debug = 0;
 	KP_liberation_respawn_cooldown = 900;
+	KP_liberation_clear_cargo = 1;
 };
 
 if (GRLIB_fatigue < 0.1) then {GRLIB_fatigue = false} else {GRLIB_fatigue = true};
@@ -106,6 +108,7 @@ if (KP_liberation_mobilearsenal == 1) then {KP_liberation_mobilearsenal = true} 
 if (KP_liberation_ailogistics == 1) then {KP_liberation_ailogistics = true} else {KP_liberation_ailogistics = false};
 if (KP_liberation_ace == 1) then {KP_liberation_ace = true} else {KP_liberation_ace = false};
 if (KP_liberation_cr_param_buildings == 1) then {KP_liberation_cr_param_buildings = true} else {KP_liberation_cr_param_buildings = false};
+if (KP_liberation_clear_cargo == 1) then {KP_liberation_clear_cargo = true} else {KP_liberation_clear_cargo = false};
 
 // Fix for not working float values in mission params
 switch (GRLIB_unitcap) do {

--- a/Missionframework/scripts/shared/functions/F_libSpawnVehicle.sqf
+++ b/Missionframework/scripts/shared/functions/F_libSpawnVehicle.sqf
@@ -27,10 +27,12 @@ if ( _classname in opfor_choppers ) then {
 };
 _newvehicle allowdamage false;
 
-clearWeaponCargoGlobal _newvehicle;
-clearMagazineCargoGlobal _newvehicle;
-clearItemCargoGlobal _newvehicle;
-clearBackpackCargoGlobal _newvehicle;
+if(KP_liberation_clear_cargo) then {
+	clearWeaponCargoGlobal _newvehicle;
+	clearMagazineCargoGlobal _newvehicle;
+	clearItemCargoGlobal _newvehicle;
+	clearBackpackCargoGlobal _newvehicle;
+};
 
 if ( _classname in militia_vehicles ) then {
 	[ _newvehicle ] call F_libSpawnMilitiaCrew;

--- a/Missionframework/stringtable.xml
+++ b/Missionframework/stringtable.xml
@@ -2377,6 +2377,9 @@
 			<Chinesesimp>伞降</Chinesesimp>
 			<Turkish>HALO ATLAYIŞI</Turkish>
 		</Key>
+		<Key ID="STR_PARAM_CLEAR_CARGO">
+			<Original>Clear vehicle cargo</Original>
+		</Key>
 		<Key ID="STR_DEPLOY_IN_PROGRESS">
 			<Original>Deployment in progress...</Original>
 			<French>Déploiement en cours...</French>

--- a/Missionframework/stringtable.xml
+++ b/Missionframework/stringtable.xml
@@ -2378,7 +2378,7 @@
 			<Turkish>HALO ATLAYIŞI</Turkish>
 		</Key>
 		<Key ID="STR_PARAM_CLEAR_CARGO">
-			<Original>Clear vehicle cargo</Original>
+			<Original>Clear spawned vehicle cargo</Original>
 		</Key>
 		<Key ID="STR_DEPLOY_IN_PROGRESS">
 			<Original>Deployment in progress...</Original>

--- a/Missionframework/ui/mission_params.hpp
+++ b/Missionframework/ui/mission_params.hpp
@@ -251,6 +251,12 @@ class Params
 		texts[] = { $STR_HALO_PARAM1, $STR_HALO_PARAM2, $STR_HALO_PARAM3, $STR_HALO_PARAM4, $STR_HALO_PARAM5, $STR_HALO_PARAM6, $STR_PARAMS_DISABLED };
 		default = 0;
 	};
+	class ClearCargo {
+		title = $STR_PARAM_CLEAR_CARGO;
+		values[] = {1,0};
+		texts[] = { $STR_PARAMS_ENABLED, $STR_PARAMS_DISABLED };
+		default = 1;
+	};
 	class Spacer3 {
 		title = "";
 		values[] = { "" };


### PR DESCRIPTION
This commit adds mission parameter which disables clearing of cargo from vehicles.

This allows to use weapons stored in RHS vehicles, so u can take that BMP down with RPG from captured GAZ ;-)

Cargo clearing is enabled by default to preserve current behaviour.