### PR TITLE
Automatically detect if vehicles are an UAV

### DIFF
--- a/Missionframework/presets/init_presets.sqf
+++ b/Missionframework/presets/init_presets.sqf
@@ -127,7 +127,7 @@ all_hostile_classnames = (land_vehicles_classnames + opfor_air + opfor_choppers 
 air_vehicles_classnames = [] + opfor_choppers;
 KP_liberation_friendly_air_classnames = [];
 {air_vehicles_classnames pushback (_x select 0); KP_liberation_friendly_air_classnames pushback (_x select 0);} foreach air_vehicles;
-{ if(_x call F_isClassUAV) then { KP_liberation_friendly_air_classnames = KP_liberation_friendly_air_classnames - [_x] };} foreach KP_liberation_friendly_air_classnames;
+KP_liberation_friendly_air_classnames = KP_liberation_friendly_air_classnames select {!(_x call F_isClassUAV)};
 KP_liberation_static_classnames = [];
 {KP_liberation_static_classnames pushback (_x select 0);} forEach static_vehicles;
 ai_resupply_sources = ai_resupply_sources + [Respawn_truck_typename, huron_typename, Arsenal_typename];

--- a/Missionframework/presets/init_presets.sqf
+++ b/Missionframework/presets/init_presets.sqf
@@ -127,7 +127,7 @@ all_hostile_classnames = (land_vehicles_classnames + opfor_air + opfor_choppers 
 air_vehicles_classnames = [] + opfor_choppers;
 KP_liberation_friendly_air_classnames = [];
 {air_vehicles_classnames pushback (_x select 0); KP_liberation_friendly_air_classnames pushback (_x select 0);} foreach air_vehicles;
-KP_liberation_friendly_air_classnames = KP_liberation_friendly_air_classnames - uavs;
+{ if(_x call F_isClassUAV) then { KP_liberation_friendly_air_classnames = KP_liberation_friendly_air_classnames - [_x] };} foreach KP_liberation_friendly_air_classnames;
 KP_liberation_static_classnames = [];
 {KP_liberation_static_classnames pushback (_x select 0);} forEach static_vehicles;
 ai_resupply_sources = ai_resupply_sources + [Respawn_truck_typename, huron_typename, Arsenal_typename];

--- a/Missionframework/scripts/client/actions/recycle_manager.sqf
+++ b/Missionframework/scripts/client/actions/recycle_manager.sqf
@@ -24,7 +24,7 @@ while {true} do {
 	if ([player, 4] call F_fetchPermission) then {
 		private _detected_vehicles = [
 			(getPos player) nearObjects veh_action_detect_distance, {
-				(((typeof _x in _recycleable_classnames ) && (({alive _x} count (crew _x)) == 0 || (typeof _x) in uavs) && ((locked _x == 0 || locked _x == 1))) ||
+				(((typeof _x in _recycleable_classnames ) && (({alive _x} count (crew _x)) == 0 || (unitIsUAV _x)) && ((locked _x == 0 || locked _x == 1))) ||
 				((typeOf _x) in _building_classnames) ||
 				(((typeOf _x) in KP_liberation_storage_buildings) && ((_x getVariable ["KP_liberation_storage_type",-1]) == 0)) ||
 				((typeOf _x) in KP_liberation_upgrade_buildings) ||

--- a/Missionframework/scripts/client/build/do_build.sqf
+++ b/Missionframework/scripts/client/build/do_build.sqf
@@ -314,7 +314,7 @@ while { true } do {
 					[_vehicle] remoteExec ["arty_monitor", 2];
 				};*/
 
-				if ( (_classname in uavs) || manned ) then {
+				if ( (unitIsUAV _vehicle) || manned ) then {
 					[ _vehicle ] call F_forceBluforCrew;
 				};
 

--- a/Missionframework/scripts/client/build/open_build_menu.sqf
+++ b/Missionframework/scripts/client/build/open_build_menu.sqf
@@ -126,7 +126,7 @@ while {dialog && alive player && (dobuild == 0 || buildtype == 1)} do {
 			((_build_item select 2 == 0 ) || ((_build_item select 2) <= ((_actual_fob select 0) select 2))) &&
 			((_build_item select 3 == 0 ) || ((_build_item select 3) <= ((_actual_fob select 0) select 3)))
 		) then {
-			if (((_build_item select 0) in KP_liberation_friendly_air_classnames) && !((_build_item select 0) in uavs)) then {
+			if (((_build_item select 0) in KP_liberation_friendly_air_classnames) && !([_build_item select 0] call F_isClassUAV)) then {
 				if (KP_liberation_air_vehicle_building_near &&
 					((((_build_item select 0) isKindOf "Helicopter") && (KP_liberation_heli_count < KP_liberation_heli_slots)) ||
 					(((_build_item select 0) isKindOf "Plane") && (KP_liberation_plane_count < KP_liberation_plane_slots)))

--- a/Missionframework/scripts/shared/functions/F_getGroupType.sqf
+++ b/Missionframework/scripts/shared/functions/F_getGroupType.sqf
@@ -20,44 +20,41 @@ if ((_grouptype == 'infantry') && (_vehicletype != '')) then {
 	} foreach heavy_vehicles;
 
 	if ( _grouptype == 'infantry' ) then {
-	{
-		if  ( _vehicletype == (_x select 0)) then {
-			if ( _vehicletype in uavs ) then {
-				_grouptype = 'uav';
-			} else {
+		{
+			if  ( _vehicletype == (_x select 0)) then {
 				_grouptype = 'air';
 			};
-		};
-	} foreach air_vehicles;
+		} foreach air_vehicles;
 	};
 
 	if ( _grouptype == 'infantry' ) then {
-	{
-		if  ( _vehicletype == (_x select 0)) then {
-			if ( _vehicletype in uavs ) then {
-				_grouptype = 'uav';
-			} else {
+		{
+			if  ( _vehicletype == (_x select 0)) then {
 				_grouptype = 'light';
 			};
-		};
-	} foreach light_vehicles;
+		} foreach light_vehicles;
 	};
 
 
 	if ( _grouptype == 'infantry' ) then {
-	{
-		if  ( _vehicletype == (_x select 0)) then {
-			_grouptype = 'support';
-		};
-	} foreach support_vehicles;
+		{
+			if  ( _vehicletype == (_x select 0)) then {
+				_grouptype = 'support';
+			};
+		} foreach support_vehicles;
 	};
 
 	if ( _grouptype == 'infantry' ) then {
-	{
-		if  ( _vehicletype == (_x select 0)) then {
-			_grouptype = 'static';
-		};
-	} foreach static_vehicles;
+		{
+			if  ( _vehicletype == (_x select 0)) then {
+				_grouptype = 'static';
+			};
+		} foreach static_vehicles;
+	};
+
+	// Check if vehicle config says it's an UAV, if it is always set its _grouptype to 'uav'
+	if ( (_vehicletype call F_isClassUAV) ) then {
+		_grouptype = 'uav';
 	};
 
 };

--- a/Missionframework/scripts/shared/functions/F_kp_isClassUAV.sqf
+++ b/Missionframework/scripts/shared/functions/F_kp_isClassUAV.sqf
@@ -1,0 +1,21 @@
+/*
+F_kp_isClassUAV.sqf
+Author: veteran29
+
+Description:
+Returns if given vehicle class is an UAV
+
+Parameters:
+_this select 0 - STRING - Class of object which will be checked if it is an UAV
+
+Return:
+BOOL
+*/
+params ["_vehicleclass"];
+
+private _isUAV = false;
+if( getNumber(configFile >> "CfgVehicles" >> _vehicleclass >> "isUav") == 1 && (typeName  _vehicleclass == "STRING") ) then {
+	_isUAV = true;
+};
+
+_isUAV;

--- a/Missionframework/scripts/shared/liberation_functions.sqf
+++ b/Missionframework/scripts/shared/liberation_functions.sqf
@@ -56,3 +56,4 @@ F_cr_ace_action = compileFinal preprocessFileLineNumbers "scripts\shared\functio
 F_getResistanceTier = compileFinal preprocessFileLineNumbers "scripts\shared\functions\F_kp_getResistanceTier.sqf";
 F_spawnGuerillaGroup = compileFinal preprocessFileLineNumbers "scripts\shared\functions\F_kp_spawnGuerillaGroup.sqf";
 F_createCrate = compileFinal preprocessFileLineNumbers "scripts\shared\functions\F_kp_createCrate.sqf";
+F_isClassUAV = compileFinal preprocessFileLineNumbers "scripts\shared\functions\F_kp_isClassUAV.sqf";


### PR DESCRIPTION
Automatically detect if vehicles are an UAVs. This allows to remove _uavs_ array from presets.

If u think having array of _uavs_ could be usefull for future functionalities there is alternative (and less "invasive") way to implement this:

_uavs_ array could be built dynamicly in _init_presets.sqf_, with this approach rest of the code could be left intact.