### PR TITLE
Fix vehicle crews and paradrop pilots not forced into corect side

### DIFF
--- a/Missionframework/scripts/server/patrols/send_paratroopers.sqf
+++ b/Missionframework/scripts/server/patrols/send_paratroopers.sqf
@@ -12,7 +12,9 @@ private _newvehicle = createVehicle [_chopper_type, markerpos _spawnsector, [], 
 createVehicleCrew _newvehicle;
 sleep 0.1;
 
-private _pilot_group = group ((crew _newvehicle) select 0);
+private _pilot_group = createGroup GRLIB_side_enemy;
+(crew _newvehicle) joinSilent _pilot_group;
+
 private _para_group = createGroup GRLIB_side_enemy;
 
 _newvehicle addMPEventHandler ["MPKilled", {_this spawn kill_manager}];

--- a/Missionframework/scripts/shared/functions/F_libSpawnVehicle.sqf
+++ b/Missionframework/scripts/shared/functions/F_libSpawnVehicle.sqf
@@ -7,6 +7,7 @@ params [
 
 private _newvehicle = objNull;
 private _spawnpos = zeropos;
+private _grp = grpNull;
 
 if ( _precise_position ) then {
 	_spawnpos = [] + _sectorpos;
@@ -37,7 +38,10 @@ if(KP_liberation_clear_cargo) then {
 if ( _classname in militia_vehicles ) then {
 	[ _newvehicle ] call F_libSpawnMilitiaCrew;
 } else {
+	_grp = createGroup GRLIB_side_enemy; //TODO test
 	createVehicleCrew _newvehicle;
+	(crew _newvehicle) joinSilent _grp;
+
 	sleep 0.1;
 	{ _x addMPEventHandler ['MPKilled', {_this spawn kill_manager}]; } foreach (crew _newvehicle);
 };


### PR DESCRIPTION
This fixes #273. 

I have played with these changes on dedicated server for few hours (~3).
Friendly side was configured to EAST and enemy to WEST. Enemy units were _takistani opfor_ and friendly were from _AFRF_, every enemy vehicle crew was correctly forced into WEST side.