### PR TITLE
Calculate fob box mass so it is always slingloadable

### DIFF
--- a/Missionframework/scripts/client/actions/do_repackage_fob.sqf
+++ b/Missionframework/scripts/client/actions/do_repackage_fob.sqf
@@ -32,7 +32,7 @@ if ( dorepackage > 0 ) then {
 
 	if ( dorepackage == 1 ) then {
 		_fobbox = FOB_box_typename createVehicle _spawnpos;
-		[_fobbox, 3000] remoteExec ["F_setMass",_fobbox];
+		_fobbox call F_setFobMass;
 	};
 
 	if ( dorepackage == 2 ) then {

--- a/Missionframework/scripts/client/build/do_build.sqf
+++ b/Missionframework/scripts/client/build/do_build.sqf
@@ -319,7 +319,7 @@ while { true } do {
 				};
 
 				switch (_classname) do {
-					case FOB_box_typename: {[_vehicle, 3000] remoteExec ["F_setMass",_vehicle];};
+					case FOB_box_typename: {_vehicle call F_setFobMass;};
 					case "Land_Medevac_house_V1_F";
 					case "Land_Medevac_HQ_V1_F": {_vehicle setVariable ["ace_medical_isMedicalFacility", true, true];};
 					case KP_liberation_recycle_building: {_vehicle setVariable ["ace_isRepairFacility", 1, true];};

--- a/Missionframework/scripts/server/base/startgame.sqf
+++ b/Missionframework/scripts/server/base/startgame.sqf
@@ -30,7 +30,7 @@ if (count GRLIB_all_fobs == 0) then {
 			_fobbox setdir getDir base_boxspawn;
 			_fobbox setposATL (getposATL base_boxspawn);	
 
-			[_fobbox, 3000] remoteExec ["F_setMass",_fobbox];
+			_fobbox call F_setFobMass;
 
 			sleep 3;
 

--- a/Missionframework/scripts/shared/functions/F_kp_setFobMass.sqf
+++ b/Missionframework/scripts/shared/functions/F_kp_setFobMass.sqf
@@ -1,0 +1,22 @@
+/*
+F_kp_setFobMass.sqf
+Author: veteran29
+
+Description:
+Sets mass of FOB box to Max slingload weight of "huron_typename" lowered by 100, 
+if max slingload mass is lower than 1000 its set to 1000
+if it is higher than 3000 it's set to 3000
+
+Parameters:
+_this select 0 - Object - FOB Box on which mass will be set
+*/
+params ["_box"];
+
+private _boxMass = getNumber(configFile >> "CfgVehicles" >> huron_typename >> "slingLoadMaxCargoMass") - 100;
+if(_boxMass < 1000) then {
+	_boxMass = 1000;
+} else {
+	if(_boxMass > 3000) then {_boxMass = 3000;};
+};
+
+[_box, _boxMass] remoteExec ["F_setMass",_box];

--- a/Missionframework/scripts/shared/liberation_functions.sqf
+++ b/Missionframework/scripts/shared/liberation_functions.sqf
@@ -58,3 +58,4 @@ F_spawnGuerillaGroup = compileFinal preprocessFileLineNumbers "scripts\shared\fu
 F_createCrate = compileFinal preprocessFileLineNumbers "scripts\shared\functions\F_kp_createCrate.sqf";
 F_isClassUAV = compileFinal preprocessFileLineNumbers "scripts\shared\functions\F_kp_isClassUAV.sqf";
 F_checkGear = compileFinal preprocessFileLineNumbers "scripts\shared\functions\F_kp_checkGear.sqf";
+F_setFobMass = compileFinal preprocessFileLineNumbers "scripts\shared\functions\F_kp_setFobMass.sqf";


### PR DESCRIPTION
Set fob box mass depending on max sling loadable mass of _huron_ helicopter.

Mass of fob can have minimum of 1000 and maximum of 3000. If max sling loadable mass of _huron_ is not in this range it will be lowered or increased to fit into this range.


After this PR, #271 _should_ be perfectly playable.