### PR TITLE
Remove unused uavs array from presets

### DIFF
--- a/Missionframework/presets/blufor/3cbBAF.sqf
+++ b/Missionframework/presets/blufor/3cbBAF.sqf
@@ -255,17 +255,6 @@ support_vehicles = [
 	["B_Slingload_01_Ammo_F",75,200,0]									//Huron Ammo
 ];
 
-// All the UAVs must be declared here, otherwise there shall be UAV controlling issues. Namely: you won't be able to control them.
-uavs = [
-	"B_UAV_01_F",														//AR-2 Darter
-	"B_UGV_01_F",														//UGV Stomper
-	"B_UGV_01_rcws_F",													//UGV Stomper (RCWS)
-	"B_UAV_02_dynamicLoadout_F",										//MQ-4A Greyhawk
-	"B_T_UAV_03_dynamicLoadout_F",										//MQ-12 Falcon
-	"B_UAV_05_F",														//UCAV Sentinel
-	"B_UAV_06_F"														//AL-6 Pelican
-];
-
 // Pre-made squads for the commander build menu. These shouldn't exceed 10 members.
 // Light infantry squad.
 blufor_squad_inf_light = [

--- a/Missionframework/presets/blufor/apex.sqf
+++ b/Missionframework/presets/blufor/apex.sqf
@@ -282,17 +282,6 @@ support_vehicles = [
 	["B_Slingload_01_Ammo_F",75,200,0]									//Huron Ammo
 ];
 
-// All the UAVs must be declared here, otherwise there shall be UAV controlling issues. Namely: you won't be able to control them.
-uavs = [
-	"B_UAV_01_F",														//AR-2 Darter
-	"B_UGV_01_F",														//UGV Stomper
-	"B_UGV_01_rcws_F",													//UGV Stomper (RCWS)
-	"B_UAV_02_dynamicLoadout_F",										//MQ-4A Greyhawk
-	"B_T_UAV_03_dynamicLoadout_F",										//MQ-12 Falcon
-	"B_UAV_05_F",														//UCAV Sentinel
-	"B_UAV_06_F"														//AL-6 Pelican
-];
-
 // Pre-made squads for the commander build menu. These shouldn't exceed 10 members.
 // Light infantry squad.
 blufor_squad_inf_light = [

--- a/Missionframework/presets/blufor/bwmod.sqf
+++ b/Missionframework/presets/blufor/bwmod.sqf
@@ -246,17 +246,6 @@ support_vehicles = [
 	["B_Slingload_01_Ammo_F",75,200,0]									//Huron Ammo
 ];
 
-// All the UAVs must be declared here, otherwise there shall be UAV controlling issues. Namely: you won't be able to control them.
-uavs = [
-	"B_UAV_01_F",														//AR-2 Darter
-	"B_UGV_01_F",														//UGV Stomper
-	"B_UGV_01_rcws_F",													//UGV Stomper (RCWS)
-	"B_UAV_02_dynamicLoadout_F",										//MQ-4A Greyhawk
-	"B_T_UAV_03_dynamicLoadout_F",										//MQ-12 Falcon
-	"B_UAV_05_F",														//UCAV Sentinel
-	"B_UAV_06_F"														//AL-6 Pelican
-];
-
 // Pre-made squads for the commander build menu. These shouldn't exceed 10 members.
 // Light infantry squad.
 blufor_squad_inf_light = [

--- a/Missionframework/presets/blufor/custom.sqf
+++ b/Missionframework/presets/blufor/custom.sqf
@@ -295,17 +295,6 @@ support_vehicles = [
 	["B_Slingload_01_Ammo_F",75,200,0]									//Huron Ammo
 ];
 
-// All the UAVs must be declared here, otherwise there shall be UAV controlling issues. Namely: you won't be able to control them.
-uavs = [
-	"B_UAV_01_F",														//AR-2 Darter
-	"B_UGV_01_F",														//UGV Stomper
-	"B_UGV_01_rcws_F",													//UGV Stomper (RCWS)
-	"B_UAV_02_dynamicLoadout_F",										//MQ-4A Greyhawk
-	"B_T_UAV_03_dynamicLoadout_F",										//MQ-12 Falcon
-	"B_UAV_05_F",														//UCAV Sentinel
-	"B_UAV_06_F"														//AL-6 Pelican
-];
-
 // Pre-made squads for the commander build menu. These shouldn't exceed 10 members.
 // Light infantry squad.
 blufor_squad_inf_light = [

--- a/Missionframework/presets/blufor/rhs_afrf.sqf
+++ b/Missionframework/presets/blufor/rhs_afrf.sqf
@@ -226,16 +226,6 @@ support_vehicles = [
 	["B_Slingload_01_Ammo_F",75,200,0]									//Huron Container Ammo
 ];
 
-// All the UAVs must be declared here, otherwise there shall be UAV controlling issues. Namely: you won't be able to control them.
-uavs = [
-	"O_UAV_01_F",														//AR-2 Tayran
-	"O_UGV_01_F",														//UGV Saif
-	"O_UGV_01_rcws_F",													//UGV Saif (RCWS)
-	"O_UAV_02_dynamicLoadout_F",										//K40 Ababil
-	"O_T_UAV_04_CAS_F",													//KH-3A
-	"O_UAV_06_F"														//AL-6 Jinaah
-];
-
 // Pre-made squads for the commander build menu. These shouldn't exceed 10 members.
 // Light infantry squad.
 blufor_squad_inf_light = [

--- a/Missionframework/presets/blufor/rhs_usaf.sqf
+++ b/Missionframework/presets/blufor/rhs_usaf.sqf
@@ -247,17 +247,6 @@ support_vehicles = [
 	["B_Slingload_01_Ammo_F",75,200,0]									//Huron Ammo
 ];
 
-// All the UAVs must be declared here, otherwise there shall be UAV controlling issues. Namely: you won't be able to control them.
-uavs = [
-	"B_UAV_01_F",														//AR-2 Darter
-	"B_UGV_01_F",														//UGV Stomper
-	"B_UGV_01_rcws_F",													//UGV Stomper (RCWS)
-	"B_UAV_02_dynamicLoadout_F",										//MQ-4A Greyhawk
-	"B_T_UAV_03_dynamicLoadout_F",										//MQ-12 Falcon
-	"B_UAV_05_F",														//UCAV Sentinel
-	"B_UAV_06_F"														//AL-6 Pelican
-];
-
 // Pre-made squads for the commander build menu. These shouldn't exceed 10 members.
 // Light infantry squad.
 blufor_squad_inf_light = [

--- a/Missionframework/presets/blufor/rhs_usaf_d.sqf
+++ b/Missionframework/presets/blufor/rhs_usaf_d.sqf
@@ -245,17 +245,6 @@ support_vehicles = [
 	["B_Slingload_01_Ammo_F",75,200,0]									//Huron Ammo
 ];
 
-// All the UAVs must be declared here, otherwise there shall be UAV controlling issues. Namely: you won't be able to control them.
-uavs = [
-	"B_UAV_01_F",														//AR-2 Darter
-	"B_UGV_01_F",														//UGV Stomper
-	"B_UGV_01_rcws_F",													//UGV Stomper (RCWS)
-	"B_UAV_02_dynamicLoadout_F",										//MQ-4A Greyhawk
-	"B_T_UAV_03_dynamicLoadout_F",										//MQ-12 Falcon
-	"B_UAV_05_F",														//UCAV Sentinel
-	"B_UAV_06_F"														//AL-6 Pelican
-];
-
 // Pre-made squads for the commander build menu. These shouldn't exceed 10 members.
 // Light infantry squad.
 blufor_squad_inf_light = [


### PR DESCRIPTION
Since #272 there is no need for uav array in preset files. It is now automatically detected if spawned object is an uav.