### PR TITLE
Fixed props saving incorrectly and buildmenu obstructions

### DIFF
--- a/Missionframework/presets/init_presets.sqf
+++ b/Missionframework/presets/init_presets.sqf
@@ -88,7 +88,14 @@ GRLIB_ignore_colisions_when_building = [
 	"B_Mortar_01_F",									//Mk6 Mortar
 	"ACE_friesAnchorBar",								//ACE FRIES
 	"ACE_friesGantryReverse",							//ACE FRIES
-	"ACE_friesGantry"									//ACE FRIES
+	"ACE_friesGantry",									//ACE FRIES
+	"Land_HBarrier_1_F",
+	"Land_HBarrier_3_F",
+	"Land_HBarrier_5_F",
+	"Land_Concrete_SmallWall_4m_F",
+	"Land_Concrete_SmallWall_8m_F",
+	"GroundWeaponHolder",				// Items on ground
+	"WeaponHolderSimulated"				// Weapon on ground
 ];
 
 

--- a/Missionframework/presets/init_presets.sqf
+++ b/Missionframework/presets/init_presets.sqf
@@ -88,14 +88,7 @@ GRLIB_ignore_colisions_when_building = [
 	"B_Mortar_01_F",									//Mk6 Mortar
 	"ACE_friesAnchorBar",								//ACE FRIES
 	"ACE_friesGantryReverse",							//ACE FRIES
-	"ACE_friesGantry",									//ACE FRIES
-	"Land_HBarrier_1_F",
-	"Land_HBarrier_3_F",
-	"Land_HBarrier_5_F",
-	"Land_Concrete_SmallWall_4m_F",
-	"Land_Concrete_SmallWall_8m_F",
-	"GroundWeaponHolder",				// Items on ground
-	"WeaponHolderSimulated"				// Weapon on ground
+	"ACE_friesGantry"									//ACE FRIES
 ];
 
 

--- a/Missionframework/scripts/client/build/do_build.sqf
+++ b/Missionframework/scripts/client/build/do_build.sqf
@@ -34,10 +34,10 @@ while { true } do {
 		_price_s = ((build_lists select buildtype) select buildindex) select 1;
 		_price_a = ((build_lists select buildtype) select buildindex) select 2;
 		_price_f = ((build_lists select buildtype) select buildindex) select 3;
-		
+
 		_nearfob = [] call F_getNearestFob;
 		_storage_areas = [_nearfob nearobjects (GRLIB_fob_range * 2), {(_x getVariable ["KP_liberation_storage_type",-1]) == 0}] call BIS_fnc_conditionalSelect;
-		
+
 		[_price_s, _price_a, _price_f, _classname, buildtype, _storage_areas] remoteExec ["build_remote_call",2];
 	};
 
@@ -157,14 +157,16 @@ while { true } do {
 
 				private _remove_objects = [];
 				{
-					if ((_x isKindOf "Animal") || ((typeof _x) in GRLIB_ignore_colisions_when_building) || (_x == player) || (_x == _vehicle) || ((typeOf _vehicle) in KP_liberation_static_classnames)) then {
+					private _typeOfX = typeOf _x;
+					if ((_x isKindOf "Animal") || (_typeOfX in GRLIB_ignore_colisions_when_building) || (_typeOfX isKindOf "CAManBase") || (isPlayer _x) || (_x == _vehicle) || ((typeOf _vehicle) in KP_liberation_static_classnames)) then {
 						_remove_objects pushback _x;
 					};
 				} foreach _near_objects;
 
 				private _remove_objects_25 = [];
 				{
-					if ((_x isKindOf "Animal") || ((typeof _x) in GRLIB_ignore_colisions_when_building) || (_x == player) || (_x == _vehicle) || ((typeOf _vehicle) in KP_liberation_static_classnames))  then {
+					private _typeOfX = typeOf _x;
+					if ((_x isKindOf "Animal") || (_typeOfX in GRLIB_ignore_colisions_when_building) || (_typeOfX isKindOf "CAManBase") || (isPlayer _x) || (_x == _vehicle) || ((typeOf _vehicle) in KP_liberation_static_classnames)) then {
 						_remove_objects_25 pushback _x;
 					};
 				} foreach _near_objects_25;
@@ -292,7 +294,7 @@ while { true } do {
 				} else {
 					_vehicle setpos _truepos;
 				};
-				
+
 				if (!(_classname in KP_liberation_ace_crates) && KP_liberation_clear_cargo) then {
 					clearWeaponCargoGlobal _vehicle;
 					clearMagazineCargoGlobal _vehicle;
@@ -328,7 +330,7 @@ while { true } do {
 					case KP_liberation_large_storage_building: {_vehicle setVariable ["KP_liberation_storage_type", 0, true];};
 					default {};
 				};
-				
+
 				if (_classname in KP_liberation_medical_vehicles) then {
 					_vehicle setVariable ["ace_medical_medicClass", 1, true];
 				};
@@ -338,7 +340,7 @@ while { true } do {
 						[_x,[[_vehicle],true]] remoteExec ["addCuratorEditableObjects",2];
 					} forEach allCurators;
 				};
-				
+
 				sleep 0.3;
 				_vehicle allowDamage true;
 				_vehicle setDamage 0;

--- a/Missionframework/scripts/client/build/do_build.sqf
+++ b/Missionframework/scripts/client/build/do_build.sqf
@@ -34,10 +34,10 @@ while { true } do {
 		_price_s = ((build_lists select buildtype) select buildindex) select 1;
 		_price_a = ((build_lists select buildtype) select buildindex) select 2;
 		_price_f = ((build_lists select buildtype) select buildindex) select 3;
-
+		
 		_nearfob = [] call F_getNearestFob;
 		_storage_areas = [_nearfob nearobjects (GRLIB_fob_range * 2), {(_x getVariable ["KP_liberation_storage_type",-1]) == 0}] call BIS_fnc_conditionalSelect;
-
+		
 		[_price_s, _price_a, _price_f, _classname, buildtype, _storage_areas] remoteExec ["build_remote_call",2];
 	};
 
@@ -157,16 +157,14 @@ while { true } do {
 
 				private _remove_objects = [];
 				{
-					private _typeOfX = typeOf _x;
-					if ((_x isKindOf "Animal") || (_typeOfX in GRLIB_ignore_colisions_when_building) || (_typeOfX isKindOf "CAManBase") || (isPlayer _x) || (_x == _vehicle) || ((typeOf _vehicle) in KP_liberation_static_classnames)) then {
+					if ((_x isKindOf "Animal") || ((typeof _x) in GRLIB_ignore_colisions_when_building) || (_x == player) || (_x == _vehicle) || ((typeOf _vehicle) in KP_liberation_static_classnames)) then {
 						_remove_objects pushback _x;
 					};
 				} foreach _near_objects;
 
 				private _remove_objects_25 = [];
 				{
-					private _typeOfX = typeOf _x;
-					if ((_x isKindOf "Animal") || (_typeOfX in GRLIB_ignore_colisions_when_building) || (_typeOfX isKindOf "CAManBase") || (isPlayer _x) || (_x == _vehicle) || ((typeOf _vehicle) in KP_liberation_static_classnames)) then {
+					if ((_x isKindOf "Animal") || ((typeof _x) in GRLIB_ignore_colisions_when_building) || (_x == player) || (_x == _vehicle) || ((typeOf _vehicle) in KP_liberation_static_classnames))  then {
 						_remove_objects_25 pushback _x;
 					};
 				} foreach _near_objects_25;
@@ -294,7 +292,7 @@ while { true } do {
 				} else {
 					_vehicle setpos _truepos;
 				};
-
+				
 				if (!(_classname in KP_liberation_ace_crates) && KP_liberation_clear_cargo) then {
 					clearWeaponCargoGlobal _vehicle;
 					clearMagazineCargoGlobal _vehicle;
@@ -330,7 +328,7 @@ while { true } do {
 					case KP_liberation_large_storage_building: {_vehicle setVariable ["KP_liberation_storage_type", 0, true];};
 					default {};
 				};
-
+				
 				if (_classname in KP_liberation_medical_vehicles) then {
 					_vehicle setVariable ["ace_medical_medicClass", 1, true];
 				};
@@ -340,7 +338,7 @@ while { true } do {
 						[_x,[[_vehicle],true]] remoteExec ["addCuratorEditableObjects",2];
 					} forEach allCurators;
 				};
-
+				
 				sleep 0.3;
 				_vehicle allowDamage true;
 				_vehicle setDamage 0;

--- a/Missionframework/scripts/server/game/save_manager.sqf
+++ b/Missionframework/scripts/server/game/save_manager.sqf
@@ -197,45 +197,40 @@ if (!isNil "greuh_liberation_savegame") then {
 	GRLIB_all_fobs = _correct_fobs;
 
 	stats_saves_loaded = stats_saves_loaded + 1;
-
+	
 	// Arty Supp deactivated for now
 	/*if (KP_liberation_suppMod_enb > 0) then {
 		waitUntil {!isNil "KP_liberation_suppMod_created"};
 	};*/
-
-	private _spawnedBuildings = [];
 
 	{
 		private _nextclass = _x select 0;
 
 		if (_nextclass in _classnames_to_save) then {
 
-			//buildings_to_save pushback [_nextclass,_savedpos,_nextdir,_hascrew,_savedvec];		OLD
-			//buildings_to_save pushback [_nextclass,_savedpos,_savedvecdir,_savedvecup,_hascrew];		NEW
-
-			private _nextpos = _x select 1;
-			private _nextvecdir = _x select 2;
-			private _nextvecup = _x select 3;
-			private _hascrew = false;
-
-			private _nextbuilding = createVehicle [_nextclass, _nextpos, [], 0, "CAN_COLLIDE"];
+			_nextpos = _x select 1;
+			_nextdir = _x select 2;
+			_hascrew = false;
+			if (count _x > 3) then {
+				_hascrew = _x select 3;
+			};
+			_nextbuilding = createVehicle [_nextclass, _nextpos, [], 0, "CAN_COLLIDE"];
+			_nextbuilding enableSimulationGlobal false;
 			_nextbuilding allowdamage false;
-			_nextbuilding enableSimulation false;
-			_spawnedBuildings pushBack _nextbuilding;
-
-			// Old savegame version (Backwards compatibility)
-			if (typeName _nextvecdir == typeName 0) then {
-				_nextbuilding setPosATL _nextpos;
-				_nextbuilding setdir _nextvecdir;	// actually a number
-				_hascrew = _x param [3, false];
-
-			// New savegame version
-			} else {
-				_nextbuilding setPosWorld _nextpos;
-				_nextbuilding setVectorDirAndUp [_nextvecdir, _nextvecup];
-				_hascrew = _x param [4, false];
+			_nextbuilding setPosATL _nextpos;
+			_nextbuilding setdamage 0;
+			_nextbuilding setdir _nextdir;
+			if (count (_x select 4) == 3) then {
+				_nextbuilding setVectorUp (_x select 4);
+				_nextbuilding setVariable ["KP_saved_vec", (_x select 4), false];
 			};
 
+			_nextbuilding enableSimulationGlobal true;
+			_nextbuilding allowdamage true;
+
+			if (_nextclass in _building_classnames) then {
+				_nextbuilding setVariable ["GRLIB_saved_pos", _nextpos, false];
+			};
 
 			// Arty Supp deactivated for now
 			/*if ((KP_liberation_suppMod_enb > 0) && (_nextclass in KP_liberation_artySupp)) then {
@@ -257,19 +252,19 @@ if (!isNil "greuh_liberation_savegame") then {
 			if (_nextclass == FOB_typename) then {
 				_nextbuilding addEventHandler ["HandleDamage", {0}];
 			};
-
+			
 			if (_nextclass in KP_liberation_medical_vehicles) then {
 				_nextbuilding setVariable ["ace_medical_medicClass", 1, true];
 			};
-
+			
 			if (_nextclass == "Land_Medevac_house_V1_F" || _nextclass == "Land_Medevac_HQ_V1_F") then {
 				_nextbuilding setVariable ["ace_medical_isMedicalFacility", true, true];
 			};
-
+			
 			if (_nextclass == KP_liberation_recycle_building) then {
 				_nextbuilding setVariable ["ace_isRepairFacility", 1, true];
 			};
-
+			
 			if (_nextclass == "Flag_White_F") then {
 				_nextbuilding setFlagTexture "res\kpflag.jpg";
 			};
@@ -296,49 +291,35 @@ if (!isNil "greuh_liberation_savegame") then {
 	} forEach buildings_to_save;
 
 	if (KP_liberation_savegame_debug > 0) then {diag_log "[KP LIBERATION] [SAVE] Saved buildings placed";};
-
+	
 	{
 		private _nextclass = _x select 0;
 
 		if (_nextclass in _classnames_to_save) then {
 
-			//KP_liberation_storages pushback [_nextclass,_savedpos,_nextdir,_supplyValue,_ammoValue,_fuelValue,_savedvec];			OLD
-			//KP_liberation_storages pushback [_nextclass,_savedpos,_savedvecdir,_savedvecup,_supplyValue,_ammoValue,_fuelValue];		NEW
-
 			private _nextpos = _x select 1;
-			private _nextvecdir = _x select 2;
-			private _nextvecup = _x select 3;
-			private _supply = 0;
-			private _ammo = 0;
-			private _fuel = 0;
+			private _nextdir = _x select 2;
 
-			private _nextbuilding = createVehicle [_nextclass, _nextpos, [], 0, "CAN_COLLIDE"];;
+			private _nextbuilding = createVehicle [_nextclass, _nextpos, [], 0, "CAN_COLLIDE"];
+			_nextbuilding enableSimulationGlobal false;
 			_nextbuilding allowdamage false;
-			_nextbuilding enableSimulation false;
-
-			// Old savegame version (Backwards compatibility)
-			if (typeName _nextvecdir == typeName 0) then {
-				_nextbuilding setPosATL _nextpos;
-				_nextbuilding setdir _nextvecdir;	// actually a number
-				_supply = floor (_x select 3);
-				_ammo = floor (_x select 4);
-				_fuel = floor (_x select 5);
-
-			// New savegame version
-			} else {
-				_nextbuilding setPosWorld _nextpos;
-				_nextbuilding setVectorDirAndUp [_nextvecdir, _nextvecup];
-				_supply = floor (_x select 4);
-				_ammo = floor (_x select 5);
-				_fuel = floor (_x select 6);
-			};
-
+			_nextbuilding setPosATL _nextpos;
 			_nextbuilding setdamage 0;
-			_nextbuilding enableSimulation true;
-			_nextbuilding allowdamage true;
-
+			_nextbuilding setdir _nextdir;
+			if (count (_x select 6) == 3) then {
+				_nextbuilding setVectorUp (_x select 6);
+				_nextbuilding setVariable ["KP_saved_vec", (_x select 6), false];
+			};
 			_nextbuilding setVariable ["KP_liberation_storage_type", 0, true];
+			_nextbuilding setVariable ["GRLIB_saved_pos", _nextpos, false];
 
+			_nextbuilding enableSimulationGlobal true;
+			_nextbuilding allowdamage true;
+			
+			private _supply = floor (_x select 3);
+			private _ammo = floor (_x select 4);
+			private _fuel = floor (_x select 5);
+			
 			while {_supply > 0} do {
 				private _amount = 100;
 				if ((_supply / 100) < 1) then {
@@ -371,14 +352,6 @@ if (!isNil "greuh_liberation_savegame") then {
 		};
 	} forEach KP_liberation_storages;
 
-	// Re-enable physics on the spawned objects
-	{
-		_x enableSimulation true;
-		_x setdamage 0;
-		_x allowdamage true;
-	} forEach _spawnedBuildings;
-
-
 	if (KP_liberation_savegame_debug > 0) then {diag_log "[KP LIBERATION] [SAVE] Saved storages placed"};
 
 	{
@@ -401,11 +374,11 @@ if (!isNil "greuh_liberation_savegame") then {
 
 			_nextbuilding enableSimulationGlobal true;
 			_nextbuilding allowdamage true;
-
+			
 			private _supply = floor (_x select 9);
 			private _ammo = floor (_x select 10);
 			private _fuel = floor (_x select 11);
-
+			
 			while {_supply > 0} do {
 				private _amount = 100;
 				if ((_supply / 100) < 1) then {
@@ -439,7 +412,7 @@ if (!isNil "greuh_liberation_savegame") then {
 	} forEach KP_liberation_production;
 
 	if (KP_liberation_savegame_debug > 0) then {diag_log "[KP LIBERATION] [SAVE] Saved sector storages placed";};
-
+	
 	{
 		private _nextgroup = _x;
 		private _grp = createGroup GRLIB_side_friendly;
@@ -512,18 +485,18 @@ while {true} do {
 			private _fobpos = _x;
 			private _nextbuildings = [_fobpos nearobjects (GRLIB_fob_range * 2), {
 				((typeof _x) in _classnames_to_save ) &&
-				(alive _x) &&					// Exclude dead or broken objects
-				(speed _x < 5) &&				// Exclude moving objects (like civilians driving through)
-				(isNull attachedTo _x) &&			// Exclude attachTo'd objects
-				(((getpos _x) select 2) < 10) &&		// Exclude hovering helicopters and the like
-				(getObjectType _x >= 8) &&			// Exclude preplaced terrain objects
-				!((typeOf _x) in KP_liberation_crates) &&	// Exclude storage crates (those are handled separately)
+				(alive _x) &&
+				(speed _x < 5) &&
+				(isNull attachedTo _x) &&
+				(((getpos _x) select 2) < 10) &&
+				(getObjectType _x >= 8) &&
+				!((typeOf _x) in KP_liberation_crates) &&
 				!(_x getVariable ["KP_liberation_preplaced", false])
  			}] call BIS_fnc_conditionalSelect;
-
+				
 			_all_buildings = [(_all_buildings + _nextbuildings), {!((typeOf _x) in KP_liberation_storage_buildings)}] call BIS_fnc_conditionalSelect;
 			_all_storages = [(_all_storages + _nextbuildings), {(_x getVariable ["KP_liberation_storage_type",-1]) == 0}] call BIS_fnc_conditionalSelect;
-
+			
 			{
 				private _nextgroup = _x;
 				if (side _nextgroup == GRLIB_side_friendly) then {
@@ -544,34 +517,56 @@ while {true} do {
 			} forEach allGroups;
 		} forEach GRLIB_all_fobs;
 
-		// Save all buildings and vehicles
 		{
-			private _savedpos = getPosWorld _x;;
-			private _savedvecdir = vectorDirVisual _x;
-			private _savedvecup = vectorUpVisual _x;;
-			private _nextclass = typeof _x;
-			private _hascrew = false;
+			private _savedpos = [];
+			private _savedvec = [];
 
+			if ((typeof _x) in _building_classnames) then {
+				_savedpos = _x getVariable ["GRLIB_saved_pos", []];
+				_savedvec = _x getVariable ["KP_saved_vec", []];
+				if ((count _savedpos == 0) || (count _savedvec == 0)) then {
+					_x setVariable ["GRLIB_saved_pos", getPosATL _x, false];
+					_x setVariable ["KP_saved_vec", vectorUpVisual _x, false];
+					_savedpos = getPosATL _x;
+					_savedvec = vectorUpVisual _x;
+				};
+			} else {
+				_savedpos = getPosATL _x;
+			};
+
+			private _nextclass = typeof _x;
+			private _nextdir = getdir _x;
+			private _hascrew = false;
 			if (_nextclass in _classnames_to_save_blu) then {
 				if (({!isPlayer _x} count (crew _x) ) > 0) then {
 					_hascrew = true;
 				};
 			};
 			if (!(_nextclass in civilian_vehicles) || (_x in KP_liberation_cr_vehicles)) then {
-				//buildings_to_save pushback [_nextclass,_savedpos,_nextdir,_hascrew,_savedvec];
-				buildings_to_save pushback [_nextclass,_savedpos,_savedvecdir,_savedvecup,_hascrew];
+				buildings_to_save pushback [_nextclass,_savedpos,_nextdir,_hascrew,_savedvec];
 			};
 		} forEach _all_buildings;
 
 		{
-			private _savedpos = getPosWorld _x;;
-			private _savedvecdir = vectorDirVisual _x;
-			private _savedvecup = vectorUpVisual _x;;
+			private _savedpos = [];
+			private _savedvec = [];
+			
+			_savedpos = _x getVariable ["GRLIB_saved_pos", []];
+			_savedvec = _x getVariable ["KP_saved_vec", []];
+			if ((count _savedpos == 0) || (count _savedvec == 0)) then {
+				_x setVariable ["GRLIB_saved_pos", getPosATL _x, false];
+				_x setVariable ["KP_saved_vec", vectorUpVisual _x, false];
+				_savedpos = getPosATL _x;
+				_savedvec = vectorUpVisual _x;
+			};
+			
 			private _nextclass = typeof _x;
+			private _nextdir = getdir _x;
+			
 			_supplyValue = 0;
 			_ammoValue = 0;
 			_fuelValue = 0;
-
+			
 			{
 				switch ((typeOf _x)) do {
 					case KP_liberation_supply_crate: {_supplyValue = _supplyValue + (_x getVariable ["KP_liberation_crate_value",0]);};
@@ -580,9 +575,8 @@ while {true} do {
 					default {diag_log format ["[KP LIBERATION] [ERROR] Invalid object (%1) at storage area", (typeOf _x)];};
 				};
 			} forEach (attachedObjects _x);
-
-			//KP_liberation_storages pushback [_nextclass,_savedpos,_nextdir,_supplyValue,_ammoValue,_fuelValue,_savedvec];
-			KP_liberation_storages pushback [_nextclass,_savedpos,_savedvecdir,_savedvecup,_supplyValue,_ammoValue,_fuelValue];
+			
+			KP_liberation_storages pushback [_nextclass,_savedpos,_nextdir,_supplyValue,_ammoValue,_fuelValue,_savedvec];		
 		} forEach _all_storages;
 
 		time_of_day = date select 3;


### PR DESCRIPTION
**When merged this pull request will:**
- fix objects not saving/respawning in the exact position they were left at - this has been an issue for the longest time and caused player-built FOBs to scramble slightly after a savegame reload, sometimes moving props up to a few meters away from their original spawn location
- fix the building menu from detecting ground items (magazines, mags, uniforms, etc.) aswell as corpses as obstructions when attempting to build vehicles or logistics items

**Note:** due to the fixes done to the save manager, the savegame format will change slightly, in that the buildings data now holds 2 vectors for an object's orientation (`vectorDirVisual` and `vectorUpVisual` for use in `setVectorDirAndUp`) rather than 1 vector (`vectorUp`?) and 1 number (`getDir`). However, **old savegame formats are fully supported** - the code is reverse compatible and will convert old formats into the new one upon loading into the mission. No further changes are required.