### PR TITLE
Move parameters loading to server only.

### DIFF
--- a/Missionframework/init.sqf
+++ b/Missionframework/init.sqf
@@ -29,6 +29,6 @@ if (!isDedicated && hasInterface) then {
 };
 
 // Execute fnc_reviveInit again (by default it executes in postInit)
-if ((!((player getVariable "bis_revive_ehHandleHeal") >= 0) || isDedicated) && !(KP_liberation_bis_revive_mode == 0)) then {
+if ((!((player getVariable "bis_revive_ehHandleHeal") >= 0) || isDedicated) && !(bis_reviveParam_mode == 0)) then {
     [] call bis_fnc_reviveInit;
 };

--- a/Missionframework/init.sqf
+++ b/Missionframework/init.sqf
@@ -29,6 +29,6 @@ if (!isDedicated && hasInterface) then {
 };
 
 // Execute fnc_reviveInit again (by default it executes in postInit)
-if ((!((player getVariable "bis_revive_ehHandleHeal") >= 0) || isDedicated) && !(bis_reviveParam_mode == 0)) then {
+if ((isNil {player getVariable "bis_revive_ehHandleHeal"} || isDedicated) && !(bis_reviveParam_mode == 0)) then {
     [] call bis_fnc_reviveInit;
 };

--- a/Missionframework/scripts/shared/defines.hpp
+++ b/Missionframework/scripts/shared/defines.hpp
@@ -4,49 +4,10 @@
 */
 
 // Get parameter
-#define GET_PARAM(outVar, paramName, paramDefault)		outVar = [paramName,paramDefault] call F_getSaveableParam;publicVariable #outVar
+#define GET_PARAM(outVar, paramName, paramDefault)	outVar = [paramName,paramDefault] call F_getSaveableParam;\
+							publicVariable #outVar
 
 // Get parameter and convert to bool
 #define GET_PARAM_BOOL(outVar, paramName, paramDefault)	outVar = [paramName,paramDefault] call F_getSaveableParam;\
-														if (outVar == 1) then {outVar = true} else {outVar = false};publicVariable #outVar
-
-/*
-	Modifiers for params conversion to float
-*/
-
-// Difficulty
-#define MOD_DIFFICULTY_TOURIST							0.5
-#define MOD_DIFFICULTY_EASY								0.75
-#define MOD_DIFFICULTY_NORMAL							1
-#define MOD_DIFFICULTY_MODERATE							1.25
-#define MOD_DIFFICULTY_HARD								1.5
-#define MOD_DIFFICULTY_EXTREME							2
-#define MOD_DIFFICULTY_LUDICROUS						4
-#define MOD_DIFFICULTY_IMPOSSIBLE						10									
-// Unitcap
-#define MOD_UNITCAP_50									0.5
-#define MOD_UNITCAP_75									0.75
-#define MOD_UNITCAP_100									1
-#define MOD_UNITCAP_125									1.25
-#define MOD_UNITCAP_150									1.50
-#define MOD_UNITCAP_200									2
-// Aggressivity
-#define MOD_AGGRESSIVTY_ANEMIC							0.25
-#define MOD_AGGRESSIVTY_WEAK							0.50
-#define MOD_AGGRESSIVTY_NORMAL							1
-#define MOD_AGGRESSIVTY_STRONG							2
-#define MOD_AGGRESSIVTY_EXTREME							4
-// Civilian Activity
-#define MOD_CIVILIANS_NONE								0
-#define MOD_CIVILIANS_REDUCED							0.5
-#define MOD_CIVILIANS_NORMAL							1
-#define MOD_CIVILIANS_INCREASED							2
-// Resources multipier
-#define MOD_RESOURCES_25								0.25
-#define MOD_RESOURCES_50								0.50
-#define MOD_RESOURCES_75								0.75
-#define MOD_RESOURCES_100								1
-#define MOD_RESOURCES_125								1.25
-#define MOD_RESOURCES_150								1.50
-#define MOD_RESOURCES_200								2
-#define MOD_RESOURCES_300								3
+							if (outVar == 1) then {outVar = true} else {outVar = false};\
+							publicVariable #outVar

--- a/Missionframework/scripts/shared/defines.hpp
+++ b/Missionframework/scripts/shared/defines.hpp
@@ -1,0 +1,52 @@
+
+/*
+	Methods
+*/
+
+// Get parameter
+#define GET_PARAM(outVar, paramName, paramDefault)		outVar = [paramName,paramDefault] call F_getSaveableParam;publicVariable #outVar
+
+// Get parameter and convert to bool
+#define GET_PARAM_BOOL(outVar, paramName, paramDefault)	outVar = [paramName,paramDefault] call F_getSaveableParam;\
+														if (outVar == 1) then {outVar = true} else {outVar = false};publicVariable #outVar
+
+/*
+	Modifiers for params conversion to float
+*/
+
+// Difficulty
+#define MOD_DIFFICULTY_TOURIST							0.5
+#define MOD_DIFFICULTY_EASY								0.75
+#define MOD_DIFFICULTY_NORMAL							1
+#define MOD_DIFFICULTY_MODERATE							1.25
+#define MOD_DIFFICULTY_HARD								1.5
+#define MOD_DIFFICULTY_EXTREME							2
+#define MOD_DIFFICULTY_LUDICROUS						4
+#define MOD_DIFFICULTY_IMPOSSIBLE						10									
+// Unitcap
+#define MOD_UNITCAP_50									0.5
+#define MOD_UNITCAP_75									0.75
+#define MOD_UNITCAP_100									1
+#define MOD_UNITCAP_125									1.25
+#define MOD_UNITCAP_150									1.50
+#define MOD_UNITCAP_200									2
+// Aggressivity
+#define MOD_AGGRESSIVTY_ANEMIC							0.25
+#define MOD_AGGRESSIVTY_WEAK							0.50
+#define MOD_AGGRESSIVTY_NORMAL							1
+#define MOD_AGGRESSIVTY_STRONG							2
+#define MOD_AGGRESSIVTY_EXTREME							4
+// Civilian Activity
+#define MOD_CIVILIANS_NONE								0
+#define MOD_CIVILIANS_REDUCED							0.5
+#define MOD_CIVILIANS_NORMAL							1
+#define MOD_CIVILIANS_INCREASED							2
+// Resources multipier
+#define MOD_RESOURCES_25								0.25
+#define MOD_RESOURCES_50								0.50
+#define MOD_RESOURCES_75								0.75
+#define MOD_RESOURCES_100								1
+#define MOD_RESOURCES_125								1.25
+#define MOD_RESOURCES_150								1.50
+#define MOD_RESOURCES_200								2
+#define MOD_RESOURCES_300								3

--- a/Missionframework/scripts/shared/fetch_params.sqf
+++ b/Missionframework/scripts/shared/fetch_params.sqf
@@ -1,3 +1,5 @@
+#include "defines.hpp"
+
 // Check if ACE is running
 if (isClass (configfile >> "CfgPatches" >> "ace_common")) then {KP_liberation_ace = true; diag_log "[KP LIBERATION] ACE detected. Deactivating resupply and weather scripts from Liberation."} else {KP_liberation_ace = false};
 
@@ -14,124 +16,126 @@ KP_liberation_kill_debug = ["DebugKill",0] call bis_fnc_getParamValue;
 KP_liberation_production_debug = ["DebugProduction",0] call bis_fnc_getParamValue;
 
 KP_load_params = ["LoadSaveParams", 1] call BIS_fnc_getParamValue;
-/* Saveable params */
 
-// Deactivate BI Revive when ACE Medical is running
-if (isClass (configfile >> "CfgPatches" >> "ace_medical")) then {
-	KP_liberation_bis_revive_mode = 0;
-	diag_log "[KP LIBERATION] ACE Medical detected. Deactivating BI Revive System."
+if(isServer) then {
+	/* Saveable params */
+
+	// Deactivate BI Revive when ACE Medical is running
+	if (isClass (configfile >> "CfgPatches" >> "ace_medical")) then {
+		bis_reviveParam_mode = 0; publicVariable "bis_reviveParam_mode";
+		diag_log "[KP LIBERATION] ACE Medical detected. Deactivating BI Revive System."
+	} else {
+		GET_PARAM(bis_reviveParam_mode, "ReviveMode", 1);
+	};
+
+	GET_PARAM(bis_reviveParam_duration, "ReviveDuration", 6);
+	GET_PARAM(bis_reviveParam_requiredTrait, "ReviveRequiredTrait", 1);
+	GET_PARAM(bis_reviveParam_medicSpeedMultiplier, "ReviveMedicSpeedMultiplier", 1);
+	GET_PARAM(bis_reviveParam_requiredItems, "ReviveRequiredItems", 1);
+	GET_PARAM(bis_reviveParam_unconsciousStateMode, "UnconsciousStateMode", 0);
+	GET_PARAM(bis_reviveParam_bleedOutDuration, "ReviveBleedOutDuration", 180);
+	GET_PARAM(bis_reviveParam_forceRespawnDuration, "ReviveForceRespawnDuration", 10);
+
+	GET_PARAM(GRLIB_difficulty_modifier, "Difficulty", 2);
+	GET_PARAM(GRLIB_time_factor, "DayDuration", 12);
+	GET_PARAM(GRLIB_resources_multiplier, "ResourcesMultiplier", 3);
+	GET_PARAM(GRLIB_unitcap, "Unitcap", 2);
+	GET_PARAM(GRLIB_civilian_activity, "civilians", 1);
+	GET_PARAM(GRLIB_halo_param, "HaloJump", 1);
+	GET_PARAM(GRLIB_cleanup_vehicles, "CleanupVehicles", 2);
+	GET_PARAM(GRLIB_csat_aggressivity, "Aggressivity", 2);
+	GET_PARAM(GRLIB_weather_param, "Weather", 3);
+	GET_PARAM(GRLIB_maximum_fobs, "MaximumFobs", 26);
+	GET_PARAM(GRLIB_max_squad_size, "MaxSquadSize", 10);
+	GET_PARAM(KP_liberation_restart, "ServerRestart", 0);
+	GET_PARAM(KP_liberation_respawn_cooldown, "RespawnCooldown", 900);
+	
+	GET_PARAM_BOOL(KP_liberation_cr_param_buildings, "CR_Building", 0);
+	GET_PARAM_BOOL(KP_liberation_ailogistics, "AiLogistics", 1);
+	GET_PARAM_BOOL(KP_liberation_clear_cargo, "ClearCargo", 1);
+	GET_PARAM_BOOL(KP_liberation_arsenalUsePreset, "ArsenalUsePreset", 1);
+	GET_PARAM_BOOL(KP_liberation_mapmarkers, "MapMarkers", 1);
+	GET_PARAM_BOOL(KP_liberation_mobilerespawn, "MobileRespawn", 1);
+	GET_PARAM_BOOL(KP_liberation_mobilearsenal, "MobileArsenal", 1);
+
+	GET_PARAM_BOOL(GRLIB_adaptive_opfor, "AdaptToPlayercount", 1);
+	GET_PARAM_BOOL(GRLIB_deployment_cinematic, "DeploymentCinematic", 1);
+	GET_PARAM_BOOL(GRLIB_fatigue, "Fatigue", 1);
+	GET_PARAM_BOOL(GRLIB_introduction, "Introduction", 1);
+	GET_PARAM_BOOL(GRLIB_teamkill_penalty, "TeamkillPenalty", 0);
+	GET_PARAM_BOOL(GRLIB_build_first_fob, "FirstFob", 0);
+	GET_PARAM_BOOL(GRLIB_permissions_param, "Permissions", 1);
+	GET_PARAM_BOOL(GRLIB_use_whitelist, "Whitelist", 0);
+	GET_PARAM_BOOL(GRLIB_shorter_nights, "ShorterNights", 0);
+	GET_PARAM_BOOL(GRLIB_blufor_defenders, "BluforDefenders", 1);
+	GET_PARAM_BOOL(GRLIB_autodanger, "Autodanger", 0);
+
+	GREUH_allow_mapmarkers = KP_liberation_mapmarkers; publicVariable "GREUH_allow_mapmarkers";
+	GREUH_allow_platoonview = KP_liberation_mapmarkers; publicVariable "GREUH_allow_platoonview";
+
+	GRLIB_remote_sensors = 0;
+	publicVariable "GRLIB_remote_sensors";
+
+	// Fix for not working float values in mission params
+	switch (GRLIB_unitcap) do {
+		case 0: {GRLIB_unitcap = MOD_UNITCAP_50;};
+		case 1: {GRLIB_unitcap = MOD_UNITCAP_75;};
+		case 2: {GRLIB_unitcap = MOD_UNITCAP_100;};
+		case 3: {GRLIB_unitcap = MOD_UNITCAP_125;};
+		case 4: {GRLIB_unitcap = MOD_UNITCAP_150;};
+		case 5: {GRLIB_unitcap = MOD_UNITCAP_200;};
+		default {GRLIB_unitcap = MOD_UNITCAP_100;};
+	};
+
+	switch (GRLIB_difficulty_modifier) do {
+		case 0: {GRLIB_difficulty_modifier = MOD_DIFFICULTY_TOURIST;};
+		case 1: {GRLIB_difficulty_modifier = MOD_DIFFICULTY_EASY;};
+		case 2: {GRLIB_difficulty_modifier = MOD_DIFFICULTY_NORMAL;};
+		case 3: {GRLIB_difficulty_modifier = MOD_DIFFICULTY_MODERATE;};
+		case 4: {GRLIB_difficulty_modifier = MOD_DIFFICULTY_HARD;};
+		case 5: {GRLIB_difficulty_modifier = MOD_DIFFICULTY_EXTREME;};
+		case 6: {GRLIB_difficulty_modifier = MOD_DIFFICULTY_LUDICROUS;};
+		case 7: {GRLIB_difficulty_modifier = MOD_DIFFICULTY_IMPOSSIBLE;};
+		default {GRLIB_difficulty_modifier = MOD_DIFFICULTY_NORMAL;};
+	};
+
+	switch (GRLIB_csat_aggressivity) do {
+		case 0: {GRLIB_csat_aggressivity = MOD_AGGRESSIVTY_ANEMIC;};
+		case 1: {GRLIB_csat_aggressivity = MOD_AGGRESSIVTY_WEAK;};
+		case 2: {GRLIB_csat_aggressivity = MOD_AGGRESSIVTY_NORMAL;};
+		case 3: {GRLIB_csat_aggressivity = MOD_AGGRESSIVTY_STRONG;};
+		case 4: {GRLIB_csat_aggressivity = MOD_AGGRESSIVTY_EXTREME;};
+		default {GRLIB_csat_aggressivity = MOD_AGGRESSIVTY_NORMAL;};
+	};
+
+	switch (GRLIB_civilian_activity) do {
+		case 0: {GRLIB_civilian_activity = MOD_CIVILIANS_NONE;};
+		case 1: {GRLIB_civilian_activity = MOD_CIVILIANS_REDUCED;};
+		case 2: {GRLIB_civilian_activity = MOD_CIVILIANS_NORMAL;};
+		case 3: {GRLIB_civilian_activity = MOD_CIVILIANS_INCREASED;};
+		default {GRLIB_civilian_activity = MOD_CIVILIANS_NORMAL;};
+	};
+
+	switch (GRLIB_resources_multiplier) do {
+		case 0: {GRLIB_resources_multiplier = MOD_RESOURCES_25;};
+		case 1: {GRLIB_resources_multiplier = MOD_RESOURCES_50;};
+		case 2: {GRLIB_resources_multiplier = MOD_RESOURCES_75;};
+		case 3: {GRLIB_resources_multiplier = MOD_RESOURCES_100;};
+		case 4: {GRLIB_resources_multiplier = MOD_RESOURCES_125;};
+		case 5: {GRLIB_resources_multiplier = MOD_RESOURCES_150;};
+		case 6: {GRLIB_resources_multiplier = MOD_RESOURCES_200;};
+		case 7: {GRLIB_resources_multiplier = MOD_RESOURCES_300;};
+		default {GRLIB_resources_multiplier = MOD_RESOURCES_100;};
+	};
+
+	KP_serverParamsFetched = true;
+	publicVariable "KP_serverParamsFetched";
+
+	diag_log "[KP LIBERATION] [PARAM] Server finished parameters initialization.";
+
 } else {
-	KP_liberation_bis_revive_mode = ["ReviveMode",1] call F_getSaveableParam;
-};
+	waitUntil {sleep 0.5; !isNil "KP_serverParamsFetched"};
+	waitUntil {sleep 0.5; KP_serverParamsFetched};
 
-KP_liberation_bis_revive_mode call bis_fnc_paramReviveMode;
-(["ReviveDuration",6] call F_getSaveableParam) call BIS_fnc_paramReviveDuration;
-(["ReviveRequiredTrait",1] call F_getSaveableParam) call BIS_fnc_paramReviveRequiredTrait;
-(["ReviveMedicSpeedMultiplier",1] call F_getSaveableParam) call BIS_fnc_paramReviveMedicSpeedMultiplier;
-(["ReviveRequiredItems",1] call F_getSaveableParam) call BIS_fnc_paramReviveRequiredItems;
-(["UnconsciousStateMode",0] call F_getSaveableParam) call BIS_fnc_paramReviveUnconsciousStateMode;
-(["ReviveBleedOutDuration",180] call F_getSaveableParam) call BIS_fnc_paramReviveBleedOutDuration;
-(["ReviveForceRespawnDuration",10] call F_getSaveableParam) call BIS_fnc_paramReviveForceRespawnDuration;
-GRLIB_difficulty_modifier = ["Difficulty",2] call F_getSaveableParam;
-GRLIB_time_factor = ["DayDuration",12] call F_getSaveableParam;
-GRLIB_resources_multiplier = ["ResourcesMultiplier",3] call F_getSaveableParam;
-GRLIB_fatigue = ["Fatigue",1] call F_getSaveableParam;
-GRLIB_introduction = ["Introduction",1] call F_getSaveableParam;
-GRLIB_deployment_cinematic = ["DeploymentCinematic",1] call F_getSaveableParam;
-GRLIB_unitcap = ["Unitcap",2] call F_getSaveableParam;
-GRLIB_adaptive_opfor = ["AdaptToPlayercount",1] call F_getSaveableParam;
-GRLIB_civilian_activity = ["civilians",1] call F_getSaveableParam;
-GRLIB_teamkill_penalty = ["TeamkillPenalty",0] call F_getSaveableParam;
-GRLIB_build_first_fob = ["FirstFob",0] call F_getSaveableParam;
-GRLIB_permissions_param = ["Permissions",1] call F_getSaveableParam;
-GRLIB_halo_param = ["HaloJump",1] call F_getSaveableParam;
-GRLIB_use_whitelist = ["Whitelist",0] call F_getSaveableParam;
-GRLIB_cleanup_vehicles = ["CleanupVehicles",2] call F_getSaveableParam;
-GRLIB_csat_aggressivity = ["Aggressivity",2] call F_getSaveableParam;
-GRLIB_weather_param = ["Weather",3] call F_getSaveableParam;
-GRLIB_shorter_nights = ["ShorterNights",0] call F_getSaveableParam;
-GRLIB_remote_sensors = 0;
-GRLIB_blufor_defenders = ["BluforDefenders",1] call F_getSaveableParam;
-GRLIB_autodanger = ["Autodanger",0] call F_getSaveableParam;
-GRLIB_maximum_fobs = ["MaximumFobs",26] call F_getSaveableParam;
-GRLIB_max_squad_size = ["MaxSquadSize",10] call F_getSaveableParam;
-KP_liberation_arsenalUsePreset = ["ArsenalUsePreset",1] call F_getSaveableParam;
-KP_liberation_mapmarkers = ["MapMarkers",1] call F_getSaveableParam;
-KP_liberation_mobilerespawn = ["MobileRespawn",1] call F_getSaveableParam;
-KP_liberation_mobilearsenal = ["MobileArsenal",1] call F_getSaveableParam;
-KP_liberation_ailogistics = ["AiLogistics",1] call F_getSaveableParam;
-KP_liberation_restart = ["ServerRestart",0] call F_getSaveableParam;
-KP_liberation_cr_param_buildings = ["CR_Building",0] call F_getSaveableParam;
-KP_liberation_respawn_cooldown = ["RespawnCooldown",900] call F_getSaveableParam;
-KP_liberation_clear_cargo = ["ClearCargo",1] call F_getSaveableParam;
-
-if (GRLIB_fatigue < 0.1) then {GRLIB_fatigue = false} else {GRLIB_fatigue = true};
-if (GRLIB_introduction == 1) then {GRLIB_introduction = true} else {GRLIB_introduction = false};
-if (GRLIB_deployment_cinematic == 1) then {GRLIB_deployment_cinematic = true} else {GRLIB_deployment_cinematic = false};
-if (GRLIB_build_first_fob == 1) then {GRLIB_build_first_fob = true} else {GRLIB_build_first_fob = false};
-if (GRLIB_teamkill_penalty == 1) then {GRLIB_teamkill_penalty = true} else {GRLIB_teamkill_penalty = false};
-if (GRLIB_adaptive_opfor == 1) then {GRLIB_adaptive_opfor = true} else {GRLIB_adaptive_opfor = false};
-if (GRLIB_permissions_param == 1) then {GRLIB_permissions_param = true} else {GRLIB_permissions_param = false};
-if (GRLIB_use_whitelist == 1) then {GRLIB_use_whitelist = true} else {GRLIB_use_whitelist = false};
-if (GRLIB_shorter_nights == 1) then {GRLIB_shorter_nights = true} else {GRLIB_shorter_nights = false};
-if (GRLIB_blufor_defenders == 1) then {GRLIB_blufor_defenders = true} else {GRLIB_blufor_defenders = false};
-if (GRLIB_autodanger == 1) then {GRLIB_autodanger = true} else {GRLIB_autodanger = false};
-if (KP_liberation_arsenalUsePreset == 1) then {KP_liberation_arsenalUsePreset = true} else {KP_liberation_arsenalUsePreset = false};
-if (KP_liberation_mapmarkers == 1) then {KP_liberation_mapmarkers = true; GREUH_allow_mapmarkers = true; GREUH_allow_platoonview = true} else {KP_liberation_mapmarkers = false; GREUH_allow_mapmarkers = false; GREUH_allow_platoonview = false; show_platoon = false; show_teammates = false; show_nametags = false};
-if (KP_liberation_mobilerespawn == 1) then {KP_liberation_mobilerespawn = true} else {KP_liberation_mobilerespawn = false};
-if (KP_liberation_mobilearsenal == 1) then {KP_liberation_mobilearsenal = true} else {KP_liberation_mobilearsenal = false};
-if (KP_liberation_ailogistics == 1) then {KP_liberation_ailogistics = true} else {KP_liberation_ailogistics = false};
-if (KP_liberation_cr_param_buildings == 1) then {KP_liberation_cr_param_buildings = true} else {KP_liberation_cr_param_buildings = false};
-if (KP_liberation_clear_cargo == 1) then {KP_liberation_clear_cargo = true} else {KP_liberation_clear_cargo = false};
-
-// Fix for not working float values in mission params
-switch (GRLIB_unitcap) do {
-	case 0: {GRLIB_unitcap = 0.5;};
-	case 1: {GRLIB_unitcap = 0.75;};
-	case 2: {GRLIB_unitcap = 1;};
-	case 3: {GRLIB_unitcap = 1.25;};
-	case 4: {GRLIB_unitcap = 1.5;};
-	case 5: {GRLIB_unitcap = 2;};
-	default {GRLIB_unitcap = 1;};
-};
-
-switch (GRLIB_difficulty_modifier) do {
-	case 0: {GRLIB_difficulty_modifier = 0.5;};
-	case 1: {GRLIB_difficulty_modifier = 0.75;};
-	case 2: {GRLIB_difficulty_modifier = 1;};
-	case 3: {GRLIB_difficulty_modifier = 1.25;};
-	case 4: {GRLIB_difficulty_modifier = 1.5;};
-	case 5: {GRLIB_difficulty_modifier = 2;};
-	case 6: {GRLIB_difficulty_modifier = 4;};
-	case 7: {GRLIB_difficulty_modifier = 10;};
-	default {GRLIB_difficulty_modifier = 1;};
-};
-
-switch (GRLIB_csat_aggressivity) do {
-	case 0: {GRLIB_csat_aggressivity = 0.25;};
-	case 1: {GRLIB_csat_aggressivity = 0.5;};
-	case 2: {GRLIB_csat_aggressivity = 1;};
-	case 3: {GRLIB_csat_aggressivity = 2;};
-	case 4: {GRLIB_csat_aggressivity = 4;};
-	default {GRLIB_csat_aggressivity = 1;};
-};
-
-switch (GRLIB_civilian_activity) do {
-	case 0: {GRLIB_civilian_activity = 0;};
-	case 1: {GRLIB_civilian_activity = 0.5;};
-	case 2: {GRLIB_civilian_activity = 1;};
-	case 3: {GRLIB_civilian_activity = 2;};
-	default {GRLIB_csat_aggressivity = 1;};
-};
-
-switch (GRLIB_resources_multiplier) do {
-	case 0: {GRLIB_resources_multiplier = 0.25;};
-	case 1: {GRLIB_resources_multiplier = 0.5;};
-	case 2: {GRLIB_resources_multiplier = 0.75;};
-	case 3: {GRLIB_resources_multiplier = 1;};
-	case 4: {GRLIB_resources_multiplier = 1.25;};
-	case 5: {GRLIB_resources_multiplier = 1.5;};
-	case 6: {GRLIB_resources_multiplier = 2;};
-	case 7: {GRLIB_resources_multiplier = 3;};
-	default {GRLIB_resources_multiplier = 1;};
+	private _text = format ["[KP LIBERATION] [PARAM] Client %1 received parameters from server.", debug_source]; _text remoteExec [diag_log,2];
 };

--- a/Missionframework/scripts/shared/fetch_params.sqf
+++ b/Missionframework/scripts/shared/fetch_params.sqf
@@ -78,54 +78,54 @@ if(isServer) then {
 
 	// Fix for not working float values in mission params
 	switch (GRLIB_unitcap) do {
-		case 0: {GRLIB_unitcap = MOD_UNITCAP_50;};
-		case 1: {GRLIB_unitcap = MOD_UNITCAP_75;};
-		case 2: {GRLIB_unitcap = MOD_UNITCAP_100;};
-		case 3: {GRLIB_unitcap = MOD_UNITCAP_125;};
-		case 4: {GRLIB_unitcap = MOD_UNITCAP_150;};
-		case 5: {GRLIB_unitcap = MOD_UNITCAP_200;};
-		default {GRLIB_unitcap = MOD_UNITCAP_100;};
+		case 0: {GRLIB_unitcap = 0.5;};
+		case 1: {GRLIB_unitcap = 0.75;};
+		case 2: {GRLIB_unitcap = 1;};
+		case 3: {GRLIB_unitcap = 1.25;};
+		case 4: {GRLIB_unitcap = 1.5;};
+		case 5: {GRLIB_unitcap = 2;};
+		default {GRLIB_unitcap = 1;};
 	};
 
 	switch (GRLIB_difficulty_modifier) do {
-		case 0: {GRLIB_difficulty_modifier = MOD_DIFFICULTY_TOURIST;};
-		case 1: {GRLIB_difficulty_modifier = MOD_DIFFICULTY_EASY;};
-		case 2: {GRLIB_difficulty_modifier = MOD_DIFFICULTY_NORMAL;};
-		case 3: {GRLIB_difficulty_modifier = MOD_DIFFICULTY_MODERATE;};
-		case 4: {GRLIB_difficulty_modifier = MOD_DIFFICULTY_HARD;};
-		case 5: {GRLIB_difficulty_modifier = MOD_DIFFICULTY_EXTREME;};
-		case 6: {GRLIB_difficulty_modifier = MOD_DIFFICULTY_LUDICROUS;};
-		case 7: {GRLIB_difficulty_modifier = MOD_DIFFICULTY_IMPOSSIBLE;};
-		default {GRLIB_difficulty_modifier = MOD_DIFFICULTY_NORMAL;};
+		case 0: {GRLIB_difficulty_modifier = 0.5;};
+		case 1: {GRLIB_difficulty_modifier = 0.75;};
+		case 2: {GRLIB_difficulty_modifier = 1;};
+		case 3: {GRLIB_difficulty_modifier = 1.25;};
+		case 4: {GRLIB_difficulty_modifier = 1.5;};
+		case 5: {GRLIB_difficulty_modifier = 2;};
+		case 6: {GRLIB_difficulty_modifier = 4;};
+		case 7: {GRLIB_difficulty_modifier = 10;};
+		default {GRLIB_difficulty_modifier = 1;};
 	};
 
 	switch (GRLIB_csat_aggressivity) do {
-		case 0: {GRLIB_csat_aggressivity = MOD_AGGRESSIVTY_ANEMIC;};
-		case 1: {GRLIB_csat_aggressivity = MOD_AGGRESSIVTY_WEAK;};
-		case 2: {GRLIB_csat_aggressivity = MOD_AGGRESSIVTY_NORMAL;};
-		case 3: {GRLIB_csat_aggressivity = MOD_AGGRESSIVTY_STRONG;};
-		case 4: {GRLIB_csat_aggressivity = MOD_AGGRESSIVTY_EXTREME;};
-		default {GRLIB_csat_aggressivity = MOD_AGGRESSIVTY_NORMAL;};
+		case 0: {GRLIB_csat_aggressivity = 0.25;};
+		case 1: {GRLIB_csat_aggressivity = 0.5;};
+		case 2: {GRLIB_csat_aggressivity = 1;};
+		case 3: {GRLIB_csat_aggressivity = 2;};
+		case 4: {GRLIB_csat_aggressivity = 4;};
+		default {GRLIB_csat_aggressivity = 1;};
 	};
 
 	switch (GRLIB_civilian_activity) do {
-		case 0: {GRLIB_civilian_activity = MOD_CIVILIANS_NONE;};
-		case 1: {GRLIB_civilian_activity = MOD_CIVILIANS_REDUCED;};
-		case 2: {GRLIB_civilian_activity = MOD_CIVILIANS_NORMAL;};
-		case 3: {GRLIB_civilian_activity = MOD_CIVILIANS_INCREASED;};
-		default {GRLIB_civilian_activity = MOD_CIVILIANS_NORMAL;};
+		case 0: {GRLIB_civilian_activity = 0;};
+		case 1: {GRLIB_civilian_activity = 0.5;};
+		case 2: {GRLIB_civilian_activity = 1;};
+		case 3: {GRLIB_civilian_activity = 2;};
+		default {GRLIB_csat_aggressivity = 1;};
 	};
 
 	switch (GRLIB_resources_multiplier) do {
-		case 0: {GRLIB_resources_multiplier = MOD_RESOURCES_25;};
-		case 1: {GRLIB_resources_multiplier = MOD_RESOURCES_50;};
-		case 2: {GRLIB_resources_multiplier = MOD_RESOURCES_75;};
-		case 3: {GRLIB_resources_multiplier = MOD_RESOURCES_100;};
-		case 4: {GRLIB_resources_multiplier = MOD_RESOURCES_125;};
-		case 5: {GRLIB_resources_multiplier = MOD_RESOURCES_150;};
-		case 6: {GRLIB_resources_multiplier = MOD_RESOURCES_200;};
-		case 7: {GRLIB_resources_multiplier = MOD_RESOURCES_300;};
-		default {GRLIB_resources_multiplier = MOD_RESOURCES_100;};
+		case 0: {GRLIB_resources_multiplier = 0.25;};
+		case 1: {GRLIB_resources_multiplier = 0.5;};
+		case 2: {GRLIB_resources_multiplier = 0.75;};
+		case 3: {GRLIB_resources_multiplier = 1;};
+		case 4: {GRLIB_resources_multiplier = 1.25;};
+		case 5: {GRLIB_resources_multiplier = 1.5;};
+		case 6: {GRLIB_resources_multiplier = 2;};
+		case 7: {GRLIB_resources_multiplier = 3;};
+		default {GRLIB_resources_multiplier = 1;};
 	};
 
 	KP_serverParamsFetched = true;

--- a/Missionframework/scripts/shared/fetch_params.sqf
+++ b/Missionframework/scripts/shared/fetch_params.sqf
@@ -137,5 +137,5 @@ if(isServer) then {
 	waitUntil {sleep 0.5; !isNil "KP_serverParamsFetched"};
 	waitUntil {sleep 0.5; KP_serverParamsFetched};
 
-	private _text = format ["[KP LIBERATION] [PARAM] Client %1 received parameters from server.", debug_source]; _text remoteExec [diag_log,2];
+	private _text = format ["[KP LIBERATION] [PARAM] Client %1 received parameters from server.", debug_source]; _text remoteExec ["diag_log",2];
 };


### PR DESCRIPTION
As we discussed earlier on Discord, I have moved saveable parameters to be loaded by server only. Clients will wait for server to load everything.

I have created `shared/defines.hpp`  file which contains macros used to load parameters. Also values used to convert params to floats were moved here, if you think this was not a good decision feel free to revert this part ;)