### PR TITLE
Scaling economy idea

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Added: Czech translation. Thanks to [MJVEVERUSKA](https://github.com/MJVEVERUSKA)
 * Added: Ability to carry ressource crates.
 * Added: Scripts/configs to setup and run development environment from VSCode tasks
+* Added: Optional parameter to enable a scaling economy penalty based on the number of FOBs built.
 * Updated: Italian localization. Thanks to [k4s0](https://github.com/k4s0)
 * Tweaked: Splitted the config file in separate files, as it was getting quite big.
 * Tweaked: Unified the prefix of all variables to `KPLIB_`.

--- a/Missionframework/CfgFunctions.hpp
+++ b/Missionframework/CfgFunctions.hpp
@@ -30,6 +30,7 @@ class KPLIB {
         class getBluforRatio            {};
         class getCommander              {};
         class getCrateHeight            {};
+        class getFobCount               {};
         class getFobName                {};
         class getFobResources           {};
         class getGroupType              {};

--- a/Missionframework/functions/fn_getFobCount.sqf
+++ b/Missionframework/functions/fn_getFobCount.sqf
@@ -1,0 +1,17 @@
+/*
+    File: fn_getFobCount.sqf
+    Author: KP Liberation Dev Team (FatRefrigerator) - https://github.com/KillahPotatoes
+    Date: 2024-09-21
+    Last Update: 2024-09-21
+    License: MIT License - http://www.opensource.org/licenses/MIT
+
+    Description:
+        Gets the number of FOBs the players have built
+
+    Parameter(s):
+        NONE
+    Returns:
+        number (number of FOBs)
+*/
+
+count KPLIB_sectors_fob;

--- a/Missionframework/scripts/client/build/do_build.sqf
+++ b/Missionframework/scripts/client/build/do_build.sqf
@@ -8,6 +8,8 @@ _maxdist = KPLIB_range_fob;
 _truepos = [];
 _debug_colisions = false;
 KP_vector = true;
+fob_count = 1;
+if(KPLIB_param_ecoScale) then {fob_count = [] call KPLIB_fnc_getFobCount}; 
 
 private _object_spheres = [];
 private _fob_spheres = [];
@@ -36,9 +38,9 @@ while { true } do {
         _classname = KPLIB_b_fobBuilding;
     } else {
         _classname = ((KPLIB_buildList select buildtype) select buildindex) select 0;
-        _price_s = ((KPLIB_buildList select buildtype) select buildindex) select 1;
-        _price_a = ((KPLIB_buildList select buildtype) select buildindex) select 2;
-        _price_f = ((KPLIB_buildList select buildtype) select buildindex) select 3;
+        _price_s = (((KPLIB_buildList select buildtype) select buildindex) select 1) * fob_count;
+        _price_a = (((KPLIB_buildList select buildtype) select buildindex) select 2) * fob_count;
+        _price_f = (((KPLIB_buildList select buildtype) select buildindex) select 3) * fob_count;
 
         _nearfob = [] call KPLIB_fnc_getNearestFob;
         _storage_areas = (_nearfob nearobjects (KPLIB_range_fob * 2)) select {(_x getVariable ["KPLIB_storage_type",-1]) == 0};
@@ -264,9 +266,9 @@ while { true } do {
 
             if ( !alive player || build_confirmed == 3 ) then {
                 private ["_price_s", "_price_a", "_price_f", "_nearfob", "_storage_areas"];
-                _price_s = ((KPLIB_buildList select buildtype) select buildindex) select 1;
-                _price_a = ((KPLIB_buildList select buildtype) select buildindex) select 2;
-                _price_f = ((KPLIB_buildList select buildtype) select buildindex) select 3;
+                _price_s = (((KPLIB_buildList select buildtype) select buildindex) select 1) * fob_count;
+                _price_a = (((KPLIB_buildList select buildtype) select buildindex) select 2) * fob_count;
+                _price_f = (((KPLIB_buildList select buildtype) select buildindex) select 3) * fob_count;
 
                 _nearfob = [] call KPLIB_fnc_getNearestFob;
                 _storage_areas = (_nearfob nearobjects (KPLIB_range_fob * 2)) select {(_x getVariable ["KPLIB_storage_type",-1]) == 0};

--- a/Missionframework/scripts/client/build/open_build_menu.sqf
+++ b/Missionframework/scripts/client/build/open_build_menu.sqf
@@ -10,6 +10,8 @@ dobuild = 0;
 _oldbuildtype = -1;
 _cfg = configFile >> "cfgVehicles";
 _initindex = buildindex;
+fob_count = 1;
+if(KPLIB_param_ecoScale) then {fob_count = [] call KPLIB_fnc_getFobCount};
 
 _dialog = createDialog "liberation_build";
 waitUntil { dialog };
@@ -68,7 +70,7 @@ while {dialog && alive player && (dobuild == 0 || buildtype == 1)} do {
                     default {};
                 };
 
-                ((findDisplay 5501) displayCtrl (110)) lnbAddRow [ _entrytext, format [ "%1" ,_x select 1], format [ "%1" ,_x select 2], format [ "%1" ,_x select 3]];
+                ((findDisplay 5501) displayCtrl (110)) lnbAddRow [ _entrytext, format [ "%1" ,(_x select 1)* fob_count], format [ "%1" ,(_x select 2)* fob_count], format [ "%1" ,(_x select 3)* fob_count]];
 
                 _icon = getText ( _cfg >> (_x select 0) >> "icon");
                 if(isText  (configFile >> "CfgVehicleIcons" >> _icon)) then {
@@ -81,14 +83,14 @@ while {dialog && alive player && (dobuild == 0 || buildtype == 1)} do {
                 } else {
                     _squadname = "";
                 };
-                ((findDisplay 5501) displayCtrl (110)) lnbAddRow  [_squadname, format [ "%1" ,_x select 1], format [ "%1" ,_x select 2], format [ "%1" ,_x select 3]];
+                ((findDisplay 5501) displayCtrl (110)) lnbAddRow  [_squadname, format [ "%1" ,(_x select 1)* fob_count], format [ "%1" ,(_x select 2)* fob_count], format [ "%1" ,(_x select 3)* fob_count]];
             };
 
             _affordable = true;
             if (
-                ((_x select 1 > 0) && ((_x select 1) > ((_actual_fob select 0) select 1))) ||
-                ((_x select 2 > 0) && ((_x select 2) > ((_actual_fob select 0) select 2))) ||
-                ((_x select 3 > 0) && ((_x select 3) > ((_actual_fob select 0) select 3)))
+                ((_x select 1 > 0) && ((_x select 1) * fob_count > ((_actual_fob select 0) select 1))) ||
+                ((_x select 2 > 0) && ((_x select 2) * fob_count > ((_actual_fob select 0) select 2))) ||
+                ((_x select 3 > 0) && ((_x select 3) * fob_count > ((_actual_fob select 0) select 3)))
             ) then {
                 _affordable = false;
             };
@@ -125,9 +127,9 @@ while {dialog && alive player && (dobuild == 0 || buildtype == 1)} do {
     if (dobuild == 0 && _selected_item != -1 && (_selected_item < (count _build_list))) then {
         _build_item = _build_list select _selected_item;
         if (
-            ((_build_item select 1 == 0 ) || ((_build_item select 1) <= ((_actual_fob select 0) select 1))) &&
-            ((_build_item select 2 == 0 ) || ((_build_item select 2) <= ((_actual_fob select 0) select 2))) &&
-            ((_build_item select 3 == 0 ) || ((_build_item select 3) <= ((_actual_fob select 0) select 3)))
+            ((_build_item select 1 == 0 ) || (((_build_item select 1) * fob_count) <= ((_actual_fob select 0) select 1))) &&
+            ((_build_item select 2 == 0 ) || (((_build_item select 2) * fob_count) <= ((_actual_fob select 0) select 2))) &&
+            ((_build_item select 3 == 0 ) || (((_build_item select 3) * fob_count) <= ((_actual_fob select 0) select 3)))
         ) then {
             if !((_build_item select 0) isEqualType []) then {
                 if ((toLower (_build_item select 0)) in KPLIB_b_air_classes && !([_build_item select 0] call KPLIB_fnc_isClassUAV)) then {

--- a/Missionframework/scripts/shared/fetch_params.sqf
+++ b/Missionframework/scripts/shared/fetch_params.sqf
@@ -55,6 +55,7 @@ if(isServer) then {
     GET_PARAM(KPLIB_param_weather, "Weather", 3);
     GET_PARAM_BOOL(KPLIB_param_vanillaFog, "VanillaFog", 1);
     GET_PARAM(KPLIB_param_resourcesMulti, "ResourcesMultiplier", 3);
+    GET_PARAM_BOOL(KPLIB_param_ecoScale, "EcoScale", 1);
     GET_PARAM_BOOL(KPLIB_param_arsenalType, "ArsenalType", 0);
     GET_PARAM_BOOL(KPLIB_param_directArsenal, "DirectArsenal", 0);
     GET_PARAM_BOOL(KPLIB_param_playerMenu, "PlayerMenu", 1);
@@ -300,6 +301,13 @@ if (!isDedicated && hasInterface) then {
 
     _param = localize "STR_PARAMS_RESOURCESMULTIPLIER";
     _value = format ["x%1", KPLIB_param_resourcesMulti];
+    _text = _text + format ["<font color='#ff8000'>%1</font><br />%2<br /><br />", _param, _value];
+
+    _param = localize "STR_PARAMS_ECOSCALE";
+    switch (KPLIB_param_ecoScale) do {
+        case 1: {_value = localize "STR_PARAMS_DISABLED";};
+        default {_value = localize "STR_PARAMS_ECOSCALE_YES";};
+    };
     _text = _text + format ["<font color='#ff8000'>%1</font><br />%2<br /><br />", _param, _value];
 
     _param = localize "STR_PARAMS_ARSENAL";

--- a/Missionframework/stringtable.xml
+++ b/Missionframework/stringtable.xml
@@ -1490,6 +1490,34 @@
             <Korean>군수물자 생산 비율</Korean>
             <Czech>Násobitel zdrojů</Czech>
         </Key>
+        <Key ID="STR_PARAMS_ECOSCALE">
+            <Original>Scaling Economy Penalty</Original>
+            <French>Pénalité d'économie d'échelle</French>
+            <German>Skalierungswirtschaftliche Strafe</German>
+            <Spanish>Penalización por escalamiento económico</Spanish>
+            <Russian>Штраф за масштабирование экономики</Russian>
+            <Italian>Penalità per l'economia di scala</Italian>
+            <Chinesesimp>规模经济惩罚</Chinesesimp>
+            <Chinese>規模經濟懲罰</Chinese>
+            <Turkish>Ölçek ekonomisi cezası</Turkish>
+            <Portuguese>Escalando penalização de economia</Portuguese>
+            <Korean>확장 경제 페널티</Korean>
+            <Czech>Škálovací ekonomický trest</Czech>
+        </Key>
+        <Key ID="STR_PARAMS_ECOSCALE_YES">
+            <Original>Yes (resource costs will scale with the number of FOBs)</Original>
+            <French>Oui (les coûts des ressources évolueront en fonction du nombre de FOB)</French>
+            <German>Ja (Ressourcenkosten steigen mit der Anzahl der FOBs)</German>
+            <Spanish>Sí (los costos de los recursos se escalarán con el número de FOB)</Spanish>
+            <Russian>Да (затраты на ресурсы будут масштабироваться в зависимости от количества FOB)</Russian>
+            <Italian>Sì (i costi delle risorse aumenteranno con il numero di FOB)</Italian>
+            <Chinesesimp>是的（资源成本将随着 FOB 的数量而变化）</Chinesesimp>
+            <Chinese>是（資源成本將隨著 FOB 數量的增加而增加）</Chinese>
+            <Turkish>Evet (kaynak maliyetleri FOB sayısına göre ölçeklenecektir)</Turkish>
+            <Portuguese>Sim (os custos dos recursos aumentarão com o número de FOBs)</Portuguese>
+            <Korean>예(자원 비용은 FOB 수에 따라 조정됩니다)</Korean>
+            <Czech>Ano (náklady na zdroje se budou měnit podle počtu FOB)</Czech>
+        </Key>
         <Key ID="STR_PARAMS_FATIGUE">
             <Original>Stamina</Original>
             <French>Stamina</French>

--- a/Missionframework/ui/mission_params.hpp
+++ b/Missionframework/ui/mission_params.hpp
@@ -113,6 +113,12 @@ class Params {
         texts[] = {"x0.25", "x0.5", "x0.75", "x1", "x1.25","x1.5","x2","x3"};
         default = 3;
     };
+    class EcoScale {
+        title = $STR_PARAMS_ECOSCALE;
+        values[] = {1, 0};
+        texts[] = {$STR_PARAMS_ECOSCALE_YES, $STR_PARAMS_DISABLED};
+        default = 1;
+    };
     class ArsenalType {
         title = $STR_PARAMS_ARSENAL;
         values[] = {0, 1};


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| Needs wipe? | no |

### Description:

Adds a new parameter option (default on right now, but that can obviously be changed) to have a scaling economy penalty.
This would increase the resource costs for all build menu items times the number of FOBs the players have built.
The idea came from playing Lib and noticing that very often after a certain point the resource cost of most things can become a non-issue. This can add an extra layer of thought in whether to build that next FOB or not. Think of it like the cost of maintaining the supply lines between all the FOBs.

This is really quite literally just a shower thought I had, only something for people who really want to push themselves in Lib.

### Content:
- [x] Parameter to turn this function on or off

### Successfully tested on:
- [x] Local MP
- [ ] Dedicated MP
