### PR TITLE
Fixed missing comma in opfor W. German preset, line 135

### DIFF
--- a/Missionframework/presets/enemies/gm_west_win.sqf
+++ b/Missionframework/presets/enemies/gm_west_win.sqf
@@ -124,7 +124,7 @@ KPLIB_o_troopTransports = [
     "gm_ge_army_fuchsa0_engineer_win",                                  // Fuchs (Engineer)
     "gm_ge_army_fuchsa0_reconnaissance_win",                            // Fuchs (Recon, MILAN)
     "gm_ge_army_m113a1g_apc_win",                                       // M113A3 (MG3)
-    "gm_ge_army_m113a1g_apc_milan_win"                                  // M113A3 (MILAN)
+    "gm_ge_army_m113a1g_apc_milan_win",                                 // M113A3 (MILAN)
     "gm_ge_army_ch53g"                                                  // CH-53G
 ];
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| Needs wipe? | no |

### Description:

The preset enemies\gm_west_win.sqf was missing a comma on line 135, causing enemies to not spawn

### Successfully tested on:
- [x] Local MP
- [x] Dedicated MP
