### PR TITLE
Fixed missing comma error on west german opfor preset, line 118

### DIFF
--- a/Missionframework/presets/opfor/gm_west_win.sqf
+++ b/Missionframework/presets/opfor/gm_west_win.sqf
@@ -115,7 +115,7 @@ opfor_troup_transports = [
     "gm_ge_army_fuchsa0_engineer_win",                                  // Fuchs (Engineer)
     "gm_ge_army_fuchsa0_reconnaissance_win",                            // Fuchs (Recon, MILAN)
     "gm_ge_army_m113a1g_apc_win",                                       // M113A3 (MG3)
-    "gm_ge_army_m113a1g_apc_milan_win"                                  // M113A3 (MILAN)
+    "gm_ge_army_m113a1g_apc_milan_win",                                 // M113A3 (MILAN)
     "gm_ge_army_ch53g"                                                  // CH-53G
 ];
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| Needs wipe? | no |

### Description:

The preset opfor\gm_west_win.sqf was missing a comma on line 118, causing enemies to not spawn

### Successfully tested on:
- [x] Local MP
- [x] Dedicated MP
