### PR TITLE
Fixed missing comma in opfor E. German preset, line 93

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@
 # KP-Steam
 steam_appid.txt
 kp_steam*.log
+
+# VSCode
+.vscode/*

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,3 @@
 # KP-Steam
 steam_appid.txt
 kp_steam*.log
-
-# VSCode
-.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,4 @@ steam_appid.txt
 kp_steam*.log
 
 # VSCode
-.vscode/*
+.vscode/

--- a/.vscode/sqfvm-lsp/ls-ignore.txt
+++ b/.vscode/sqfvm-lsp/ls-ignore.txt
@@ -1,0 +1,20 @@
+################################################################
+### This file contains a list of paths to ignore changes of. ###
+### The paths are relative to the workspace root.            ###
+### The paths are separated by newlines.                     ###
+### Note that this is not behaving like a .gitignore file,   ###
+### and you cannot invert some paths by prefixing them with  ###
+### a ! or use wildcards.                                    ###
+### Any subfolder of a path is also ignored.                 ###
+### Important: No leading or trailing whitespace is allowed  ###
+###            on any line.                                  ###
+### Changing anything in this file will have no effect until ###
+### the language server is restarted.                        ###
+### Keep in mind that already analyzed files will not be     ###
+### re-analyzed OR removed from the database.                ###
+################################################################
+.vscode\sqfvm-lsp
+.vscode
+.github
+.git
+.hemtt

--- a/Missionframework/presets/enemies/gm_east.sqf
+++ b/Missionframework/presets/enemies/gm_east.sqf
@@ -90,7 +90,7 @@ KPLIB_o_armyVehiclesLight = [
     "gm_gc_army_brdm2",                                                 // SPW-40P2
     "gm_gc_army_btr60pa",                                               // SPW-60PA
     "gm_gc_army_btr60pa",                                               // SPW-60PA
-    "gm_gc_army_btr60pb"                                                // SPW-60PB
+    "gm_gc_army_btr60pb",                                               // SPW-60PB
     "gm_gc_army_btr60pb"                                                // SPW-60PB
 ];
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | yes |
| Needs wipe? | no |

### Description:
An errant comma in the summer East Germany opfor preset on line 93 was preventing enemies from spawning and causing the mission to hang every second with a looping error

### Successfully tested on:
- [x] Local MP
- [x] Dedicated MP
Edit 9/12/25 Got around to testing on dedicated, confirmed working
